### PR TITLE
adding missing elements such as exception and certificateinfo to event-pre-hash string

### DIFF
--- a/core/src/main/java/io/openepcis/epc/eventhash/TemplateNodeMap.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/TemplateNodeMap.java
@@ -175,6 +175,8 @@ public class TemplateNodeMap extends LinkedHashMap<String, Object> {
 
     put("eventTimeZoneOffset", new LinkedHashMap<>());
 
+    put("certificationInfo", new LinkedHashMap<>());
+
     final LinkedHashMap<String, Object> errorCorrectiveId = new LinkedHashMap<>();
     errorCorrectiveId.put("correctiveEventID", new LinkedHashMap<>());
 
@@ -265,6 +267,7 @@ public class TemplateNodeMap extends LinkedHashMap<String, Object> {
 
     final LinkedHashMap<String, Object> sensorReport = new LinkedHashMap<>();
     sensorReport.put("type", new LinkedHashMap<>());
+    sensorReport.put("exception", new LinkedHashMap<>());
     sensorReport.put("deviceID", new LinkedHashMap<>());
     sensorReport.put("deviceMetadata", new LinkedHashMap<>());
     sensorReport.put("rawData", new LinkedHashMap<>());
@@ -286,7 +289,6 @@ public class TemplateNodeMap extends LinkedHashMap<String, Object> {
     sensorReport.put("percValue", new LinkedHashMap<>());
     sensorReport.put("uom", new LinkedHashMap<>());
     sensorReport.put("coordinateReferenceSystem", new LinkedHashMap<>());
-    sensorReport.put("exception", new LinkedHashMap<>());
 
     LinkedHashMap<String, Object> sensorElementList = new LinkedHashMap<>();
     sensorElementList.put("sensorMetadata", sensorMetadata);

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -289,4 +289,35 @@ public class EventHashGeneratorPublisherTest {
         RuntimeException.class,
         () -> EventHashGenerator.fromJson(jsonStream, "sha-512").subscribe().asStream().toList());
   }
+
+  // Test to ensure new element's exception, coordinateReferenceSystem and certificateInfo are
+  // ordered
+  @Test
+  public void withNewElementsJsonTest() throws IOException {
+    final InputStream jsonStream = getClass().getResourceAsStream("/withNewElements.json");
+    final Multi<Map<String, String>> eventHashIds =
+        EventHashGenerator.fromJson(jsonStream, new String[] {"prehash", "sha3-512"});
+    EventHashGenerator.prehashJoin("\\n");
+    eventHashIds
+        .subscribe()
+        .with(
+            jsonHash ->
+                System.out.println(jsonHash.get("prehash") + "\n" + jsonHash.get("sha3-512")),
+            failure -> System.out.println("JSON HashId Generation Failed with " + failure));
+  }
+
+  // Test to ensure new element's exception, coordinateReferenceSystem and certificateInfo are
+  // ordered
+  @Test
+  public void withNewElementsXmlTest() {
+    final InputStream jsonStream = getClass().getResourceAsStream("/withNewElements.xml");
+    EventHashGenerator.prehashJoin("\\n");
+    final Multi<Map<String, String>> eventHashIds =
+        EventHashGenerator.fromXml(jsonStream, new String[] {"prehash", "sha3-512"});
+    eventHashIds
+        .subscribe()
+        .with(
+            xmlHash -> System.out.println(xmlHash.get("prehash") + "\n" + xmlHash.get("sha3-512")),
+            failure -> System.out.println("XML HashId Generation Failed with " + failure));
+  }
 }

--- a/core/src/test/resources/withNewElements.json
+++ b/core/src/test/resources/withNewElements.json
@@ -1,0 +1,47 @@
+{
+  "@context": [
+    "https://gs1.github.io/EPCIS/epcis-context.jsonld"
+  ],
+  "type": "EPCISDocument",
+  "schemaVersion": "2.0",
+  "creationDate": "2019-10-07T15:00:00.000+01:00",
+  "epcisBody": {
+    "eventList": [
+      {
+        "type": "ObjectEvent",
+        "eventTime": "2021-05-27T10:00:00.000Z",
+        "eventTimeZoneOffset": "+01:00",
+        "epcList": [
+          "https://id.example.com/8003/040123450007718765"
+        ],
+        "action": "OBSERVE",
+        "bizStep": "sensor_reporting",
+        "readPoint": {
+          "id": "https://id.example.com/414/4012345000054"
+        },
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
+        "sensorElementList": [
+          {
+            "sensorReport": [
+              {
+                "type": "Angle",
+                "value": 42.698334,
+                "coordinateReferenceSystem": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "component": "latitude",
+                "uom": "DD",
+                "exception": "ERROR_CONDITION"
+              },
+              {
+                "coordinateReferenceSystem": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "type": "Angle",
+                "value": 23.319941,
+                "component": "longitude",
+                "uom": "DD"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/core/src/test/resources/withNewElements.xml
+++ b/core/src/test/resources/withNewElements.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<epcis:Document xmlns:epcis="urn:epcglobal:epcis:xsd:2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cbvmda="urn:epcglobal:cbv:mda:" schemaVersion="2.0" creationDate="2019-10-07T15:00:00.000+01:00">
+    <EPCISBody>
+        <EventList>
+            <ObjectEvent>
+                <eventTime>2021-05-27T10:00:00.000Z</eventTime>
+                <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
+                <epcList>
+                    <epc>https://id.example.com/8003/040123450007718765</epc>
+                </epcList>
+                <action>OBSERVE</action>
+                <bizStep>urn:epcglobal:cbv:bizstep:sensor_reporting</bizStep>
+                <readPoint>
+                    <id>https://id.example.com/414/4012345000054</id>
+                </readPoint>
+                <sensorElementList>
+                    <sensorElement>
+                        <sensorReport exception="ERROR_CONDITION" coordinateReferenceSystem="http://www.opengis.net/def/crs/OGC/1.3/CRS84" component="latitude" uom="DD" type="gs1:Angle" value="42.698334"></sensorReport>
+                        <sensorReport coordinateReferenceSystem="http://www.opengis.net/def/crs/OGC/1.3/CRS84" component="longitude" uom="DD" type="gs1:Angle" value="23.319941"></sensorReport>
+                    </sensorElement>
+                </sensorElementList>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
+            </ObjectEvent>
+        </EventList>
+    </EPCISBody>
+</epcis:Document>


### PR DESCRIPTION
This pull request contains some of the newly introduced/missing elements to the Event Hash. Based on the discussion [Event-Hash-Python-Issues](https://github.com/RalphTro/epcis-event-hash-generator/issues/75) the new elements are added according to the order.