### PR TITLE
fixing the issue with user extensions sorting order

### DIFF
--- a/core/src/main/java/io/openepcis/epc/eventhash/HashNodeComparator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/HashNodeComparator.java
@@ -53,7 +53,12 @@ public class HashNodeComparator implements Comparator<ContextNode> {
       // For the User Extensions field when both elements are not part of the epcis standard fields
       // then sort them based on the name.
       if (result == 0 && o1Index == -1 && o2Index == -1) {
-        if (o1.getName() != null && o2.getName() != null) {
+        // Check if the element is of user extension
+        if (!TemplateNodeMap.isEpcisField(o1) && !TemplateNodeMap.isEpcisField(o2)) {
+          // For user extensions consider the namespace and then sort
+          return sortUserExtensions(o1, o2);
+        } else if (o1.getName() != null && o2.getName() != null) {
+          // For dedicated epcis fields sort based on the name
           return o1.getName().compareTo(o2.getName());
         }
       } else if (result == 0) {
@@ -73,6 +78,36 @@ public class HashNodeComparator implements Comparator<ContextNode> {
       }
     }
     return 0;
+  }
+
+  private int sortUserExtensions(final ContextNode o1, final ContextNode o2) {
+    final String o1Namespace =
+        o1.getName() != null
+            ? o1.getNamespaces().get(o1.getName().substring(0, o1.getName().indexOf(":")))
+            : null;
+    final String o2Namespace =
+        o2.getName() != null
+            ? o2.getNamespaces().get(o2.getName().substring(0, o2.getName().indexOf(":")))
+            : null;
+    final String o1String =
+        o1Namespace != null
+            ? "{"
+                + o1Namespace
+                + "}"
+                + o1.getName().substring(o1.getName().indexOf(":") + 1)
+                + "="
+                + o1.getValue()
+            : o1.getName();
+    final String o2String =
+        o2Namespace != null
+            ? "{"
+                + o2Namespace
+                + "}"
+                + o2.getName().substring(o2.getName().indexOf(":") + 1)
+                + "="
+                + o2.getValue()
+            : o2.getName();
+    return o1String.compareTo(o2String);
   }
 
   // For nested hashnode values loop over its children and get values.

--- a/core/src/main/java/io/openepcis/epc/eventhash/HashNodeComparator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/HashNodeComparator.java
@@ -91,18 +91,14 @@ public class HashNodeComparator implements Comparator<ContextNode> {
             : null;
     final String o1String =
         o1Namespace != null
-            ? "{"
-                + o1Namespace
-                + "}"
+            ? o1Namespace
                 + o1.getName().substring(o1.getName().indexOf(":") + 1)
                 + "="
                 + o1.getValue()
             : o1.getName();
     final String o2String =
         o2Namespace != null
-            ? "{"
-                + o2Namespace
-                + "}"
+            ? o2Namespace
                 + o2.getName().substring(o2.getName().indexOf(":") + 1)
                 + "="
                 + o2.getValue()

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -22,21 +22,12 @@ import io.smallrye.mutiny.Multi;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
 public class EventHashGeneratorPublisherTest {
-
-  private static final String PYTHON_TOOL_API = "https://event-hash-generator.openepcis.io/hash";
-  private static final HttpRequest.Builder XML_REQUEST_BUILDER =
-      HttpRequest.newBuilder(URI.create(PYTHON_TOOL_API)).header("content-type", "application/xml");
-  private static final HttpRequest.Builder JSON_REQUEST_BUILDER =
-      HttpRequest.newBuilder(URI.create(PYTHON_TOOL_API))
-          .header("content-type", "application/json");
 
   // General test to fix bugs or necessary code modification for XML document.
   @Test
@@ -53,13 +44,8 @@ public class EventHashGeneratorPublisherTest {
   public void xmlPreHashGeneratorTest() {
     final InputStream xmlStream = getClass().getResourceAsStream("/XmlEpcisEvents.xml");
     final Multi<Map<String, String>> eventHashIds =
-        EventHashGenerator.fromXml(xmlStream, new String[] {"prehash", "sha3-512"});
+        EventHashGenerator.fromXml(xmlStream, "prehash", "sha3-512");
     assertEquals(1, eventHashIds.subscribe().asStream().toList().size());
-    /*
-        eventHashIds.subscribe().with(
-        xmlHash -> System.out.println(xmlHash),
-        failure -> System.out.println("JSON HashId Generation Failed with " + failure));
-    */
   }
 
   // General test to fix bugs or necessary code modification for JSON document.
@@ -77,13 +63,8 @@ public class EventHashGeneratorPublisherTest {
   public void jsonPreHashGeneratorTest() throws IOException {
     final InputStream jsonStream = getClass().getResourceAsStream("/JsonEpcisEvents.json");
     final Multi<Map<String, String>> eventHashIds =
-        EventHashGenerator.fromJson(jsonStream, new String[] {"prehash", "sha3-512"});
+        EventHashGenerator.fromJson(jsonStream, "prehash", "sha3-512");
     assertEquals(1, eventHashIds.subscribe().asStream().toList().size());
-    /*
-       eventHashIds.subscribe().with(
-       jsonHash -> System.out.println(jsonHash),
-       failure -> System.out.println("JSON HashId Generation Failed with " + failure));
-    */
   }
 
   // Test to ensure the pre-hash string is generated correctly for simple event.
@@ -100,22 +81,6 @@ public class EventHashGeneratorPublisherTest {
         EventHashGenerator.fromJson(jsonStream, "sha-256").subscribe().asStream().toList();
 
     assertEquals(xmlHashIds, jsonHashIds);
-
-    // Check if the response from Python Event Hash Generator is same as Java tool
-    // final HttpRequest xmlRequest =
-    // XML_REQUEST_BUILDER.POST(HttpRequest.BodyPublishers.ofString(new
-    // String(getClass().getResourceAsStream("/SingleEvent.xml").readAllBytes(),
-    // StandardCharsets.UTF_8))).build();
-    // assertEquals(HttpClient.newHttpClient().send(xmlRequest,
-    // HttpResponse.BodyHandlers.ofString()).body(), xmlHashIds.get(0));
-
-    // Check if the response from Python Event Hash Generator is same as Java tool
-    // final HttpRequest jsonRequest =
-    // JSON_REQUEST_BUILDER.POST(HttpRequest.BodyPublishers.ofString(new
-    // String(getClass().getResourceAsStream("/SingleEvent.json").readAllBytes(),
-    // StandardCharsets.UTF_8))).build();
-    // assertEquals(HttpClient.newHttpClient().send(jsonRequest,
-    // HttpResponse.BodyHandlers.ofString()).body(), jsonHashIds.get(0));
   }
 
   // Test to ensure the pre-hash string is generated correctly when errorDeclaration information are
@@ -133,22 +98,6 @@ public class EventHashGeneratorPublisherTest {
         EventHashGenerator.fromJson(jsonStream, "sha-256").subscribe().asStream().toList();
 
     assertEquals(xmlHashIds, jsonHashIds);
-
-    // Check if the response from Python Event Hash Generator is same as Java tool
-    // final HttpRequest xmlRequest =
-    // XML_REQUEST_BUILDER.POST(HttpRequest.BodyPublishers.ofString(new
-    // String(getClass().getResourceAsStream("/WithErrorDeclaration.xml").readAllBytes(),
-    // StandardCharsets.UTF_8))).build();
-    // assertEquals(HttpClient.newHttpClient().send(xmlRequest,
-    // HttpResponse.BodyHandlers.ofString()).body(), xmlHashIds.get(0));
-
-    // Check if the response from Python Event Hash Generator is same as Java tool
-    // final HttpRequest jsonRequest =
-    // JSON_REQUEST_BUILDER.POST(HttpRequest.BodyPublishers.ofString(new
-    // String(getClass().getResourceAsStream("/WithErrorDeclaration.json").readAllBytes(),
-    // StandardCharsets.UTF_8))).build();
-    // assertEquals(HttpClient.newHttpClient().send(jsonRequest,
-    // HttpResponse.BodyHandlers.ofString()).body(), jsonHashIds.get(0));
   }
 
   // Test to ensure that pre-hash string is created accurately when EPCIS document contains all
@@ -168,22 +117,6 @@ public class EventHashGeneratorPublisherTest {
         EventHashGenerator.fromJson(jsonStream, "sha-256").subscribe().asStream().toList();
 
     assertEquals(xmlHashIds, jsonHashIds);
-
-    // Check if the response from Python Event Hash Generator is same as Java tool
-    // final HttpRequest xmlRequest =
-    // XML_REQUEST_BUILDER.POST(HttpRequest.BodyPublishers.ofString(new
-    // String(getClass().getResourceAsStream("/WithFullCombinationOfFields.xml").readAllBytes(),
-    // StandardCharsets.UTF_8))).build();
-    // assertEquals(HttpClient.newHttpClient().send(xmlRequest,
-    // HttpResponse.BodyHandlers.ofString()).body(), xmlHashIds.get(0));
-
-    // Check if the response from Python Event Hash Generator is same as Java tool
-    // final HttpRequest jsonRequest =
-    // JSON_REQUEST_BUILDER.POST(HttpRequest.BodyPublishers.ofString(new
-    // String(getClass().getResourceAsStream("/WithFullCombinationOfFields.json").readAllBytes(),
-    // StandardCharsets.UTF_8))).build();
-    // assertEquals(HttpClient.newHttpClient().send(jsonRequest,
-    // HttpResponse.BodyHandlers.ofString()).body(), jsonHashIds.get(0));
   }
 
   // Test to ensure that pre-hash string is created accurately when EPCIS document contains all
@@ -205,22 +138,6 @@ public class EventHashGeneratorPublisherTest {
     System.out.println("\nXML document Generated XML Event Pre Hashes : \n" + xmlHashIds);
     System.out.println("\nJSON document Generated XML Event Pre Hashes : \n" + jsonHashIds);
     assertEquals(xmlHashIds, jsonHashIds);
-
-    // Check if the response from Python Event Hash Generator is same as Java tool
-    // final HttpRequest xmlRequest =
-    // XML_REQUEST_BUILDER.POST(HttpRequest.BodyPublishers.ofString(new
-    // String(getClass().getResourceAsStream("/WithFullCombinationOfFields.xml").readAllBytes(),
-    // StandardCharsets.UTF_8))).build();
-    // assertEquals(HttpClient.newHttpClient().send(xmlRequest,
-    // HttpResponse.BodyHandlers.ofString()).body(), xmlHashIds.get(0));
-
-    // Check if the response from Python Event Hash Generator is same as Java tool
-    // final HttpRequest jsonRequest =
-    // JSON_REQUEST_BUILDER.POST(HttpRequest.BodyPublishers.ofString(new
-    // String(getClass().getResourceAsStream("/WithFullCombinationOfFields.json").readAllBytes(),
-    // StandardCharsets.UTF_8))).build();
-    // assertEquals(HttpClient.newHttpClient().send(jsonRequest,
-    // HttpResponse.BodyHandlers.ofString()).body(), jsonHashIds.get(0));
   }
 
   // Test to ensure that order of pre-hash always remains the same even when EPCIS document values
@@ -295,29 +212,35 @@ public class EventHashGeneratorPublisherTest {
   @Test
   public void withNewElementsJsonTest() throws IOException {
     final InputStream jsonStream = getClass().getResourceAsStream("/withNewElements.json");
-    final Multi<Map<String, String>> eventHashIds =
-        EventHashGenerator.fromJson(jsonStream, new String[] {"prehash", "sha3-512"});
+    final InputStream xmlStream = getClass().getResourceAsStream("/withNewElements.xml");
+
     EventHashGenerator.prehashJoin("\\n");
+
+    final Multi<Map<String, String>> xmlEventHash =
+        EventHashGenerator.fromXml(xmlStream, "prehash", "sha3-512");
+    final String xmlHashId = xmlEventHash.subscribe().asStream().toList().get(0).get("sha3-512");
+
+    final Multi<Map<String, String>> jsonEventHash =
+        EventHashGenerator.fromJson(jsonStream, "prehash", "sha3-512");
+    final String jsonHashId = jsonEventHash.subscribe().asStream().toList().get(0).get("sha3-512");
+
+    assertEquals(xmlHashId, jsonHashId);
+  }
+
+  // Ordering of user extensions http should appear before https, JSON document
+  @Test
+  public void userExtensionsOrderJsonTest() throws IOException {
+    final InputStream jsonStream = getClass().getResourceAsStream("/UserExtensionsOrder.json");
+    EventHashGenerator.prehashJoin("\\n");
+    final Multi<Map<String, String>> eventHashIds =
+        EventHashGenerator.fromJson(jsonStream, "prehash", "sha3-512");
+
     eventHashIds
         .subscribe()
         .with(
             jsonHash ->
                 System.out.println(jsonHash.get("prehash") + "\n" + jsonHash.get("sha3-512")),
-            failure -> System.out.println("JSON HashId Generation Failed with " + failure));
-  }
-
-  // Test to ensure new element's exception, coordinateReferenceSystem and certificateInfo are
-  // ordered
-  @Test
-  public void withNewElementsXmlTest() {
-    final InputStream jsonStream = getClass().getResourceAsStream("/withNewElements.xml");
-    EventHashGenerator.prehashJoin("\\n");
-    final Multi<Map<String, String>> eventHashIds =
-        EventHashGenerator.fromXml(jsonStream, new String[] {"prehash", "sha3-512"});
-    eventHashIds
-        .subscribe()
-        .with(
-            xmlHash -> System.out.println(xmlHash.get("prehash") + "\n" + xmlHash.get("sha3-512")),
-            failure -> System.out.println("XML HashId Generation Failed with " + failure));
+            failure -> System.out.println("XML HashId Generation Failed with " + failure),
+            () -> System.out.println("Completed"));
   }
 }

--- a/core/src/test/resources/UserExtensionsOrder.json
+++ b/core/src/test/resources/UserExtensionsOrder.json
@@ -1,0 +1,45 @@
+{
+  "@context": [
+    "https://ref.gs1.org/standards/epcis/2.0.0/epcis-context.jsonld",
+    {
+      "abc": "https://ns.abc.de/epcis/",
+      "example": "http://ns.example.com/epcis/",
+      "fgh": "https://ns.fgh.co.uk/epcis/",
+      "schema": "https://schema.org/",
+      "sdo": "https://schema.org/",
+      "test": "http://example.test.com/"
+    }
+  ],
+  "type": "EPCISDocument",
+  "schemaVersion": "2.0",
+  "creationDate": "2005-07-11T11:30:47.0Z",
+  "epcisBody": {
+    "eventList": [
+      {
+        "type": "ObjectEvent",
+        "action": "OBSERVE",
+        "bizStep": "receiving",
+        "disposition": "in_progress",
+        "epcList": [
+          "https://id.gs1.org/01/70614141123451/21/2018"
+        ],
+        "eventTime": "2005-04-04T20:33:31.116-06:00",
+        "eventTimeZoneOffset": "-06:00",
+        "readPoint": {
+          "id": "urn:epc:id:sgln:0012345.11111.400"
+        },
+        "bizLocation": {
+          "id": "urn:epc:id:sgln:0012345.11111.0"
+        },
+        "fgh:a-date": "2023-10-09",
+        "example:myField": "Example of a vendor/user extension",
+        "abc:a-integer": 2,
+        "abc:z-integer": 1,
+        "test:volume": 100,
+        "schema:award": "Order of Standards",
+        "schema:mpn": "4711",
+        "sdo:nsn": "4712"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Hi @sboeckelmann 

Previously we were not considering the namespaces during the sorting of User Extensions due to this the sorting order was not considering the `http` namespaces before the `https` namespaces in pre-hash string.
Now we have fixed the issue and we are considering the namespaces into consideration. This should fix the issue created by Ralph: https://github.com/openepcis/openepcis-event-hash-generator/issues/3

Kindly request you to approve the pull request and merge to main.