### PR TITLE
fix biz transaction, source list and destination list order and fix the URN to URI conversion wordings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,6 +26,8 @@
         <version>0.9.1-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
+
+    <version>0.9.2-SNAPSHOT</version>
     <artifactId>openepcis-event-hash-generator</artifactId>
     <name>openepcis-event-hash-generator</name>
     <description>openEPCIS EPC GS1 Digital Link Translation Tools</description>
@@ -61,6 +63,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.version>0.9.2-SNAPSHOT</project.version>
     </properties>
 
     <dependencies>
@@ -68,8 +71,7 @@
         <dependency>
             <groupId>io.openepcis</groupId>
             <artifactId>openepcis-epc-digitallink-translator</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
-            <scope>compile</scope>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Mutiny dependency for Reactive Streams -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>io.openepcis</groupId>
             <artifactId>openepcis-epc-digitallink-translator</artifactId>
-            <version>${project.version}</version>
+            <version>0.9.2-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 

--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -17,7 +17,7 @@ package io.openepcis.epc.eventhash;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import io.openepcis.epc.translator.ConverterUtil;
+import io.openepcis.epc.translator.util.ConverterUtil;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/core/src/main/java/io/openepcis/epc/eventhash/TemplateNodeMap.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/TemplateNodeMap.java
@@ -238,20 +238,20 @@ public class TemplateNodeMap extends LinkedHashMap<String, Object> {
     put("bizLocation", bizLocation);
 
     final LinkedHashMap<String, Object> bizTransactionList = new LinkedHashMap<>();
-    bizTransactionList.put("bizTransaction", new LinkedHashMap<>());
     bizTransactionList.put("type", new LinkedHashMap<>());
+    bizTransactionList.put("bizTransaction", new LinkedHashMap<>());
 
     put("bizTransactionList", bizTransactionList);
 
     final LinkedHashMap<String, Object> sourceList = new LinkedHashMap<>();
-    sourceList.put("source", new LinkedHashMap<>());
     sourceList.put("type", new LinkedHashMap<>());
+    sourceList.put("source", new LinkedHashMap<>());
 
     put("sourceList", sourceList);
 
     final LinkedHashMap<String, Object> destinationList = new LinkedHashMap<>();
-    destinationList.put("destination", new LinkedHashMap<>());
     destinationList.put("type", new LinkedHashMap<>());
+    destinationList.put("destination", new LinkedHashMap<>());
 
     put("destinationList", destinationList);
 

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -36,7 +36,6 @@ public class EventHashGeneratorPublisherTest {
     final List<String> eventHashIds =
         EventHashGenerator.fromXml(xmlStream, "sha-256").subscribe().asStream().toList();
     assertEquals(1, eventHashIds.size());
-    System.out.println("\nXML document Generated Event Hash Ids : \n" + eventHashIds);
   }
 
   // General test to show pre hashes for XML document.
@@ -55,7 +54,6 @@ public class EventHashGeneratorPublisherTest {
     final List<String> eventHashIds =
         EventHashGenerator.fromJson(jsonStream, "sha3-256").subscribe().asStream().toList();
     assertEquals(1, eventHashIds.size());
-    System.out.println("\nJSON/JSON-LD document Generated Event Hash Ids : \n" + eventHashIds);
   }
 
   // General tst to show pre hashes for JSON document.
@@ -134,9 +132,6 @@ public class EventHashGeneratorPublisherTest {
         EventHashGenerator.fromXml(xmlStream, "prehash").subscribe().asStream().toList();
     final List<String> jsonHashIds =
         EventHashGenerator.fromJson(jsonStream, "prehash").subscribe().asStream().toList();
-
-    System.out.println("\nXML document Generated XML Event Pre Hashes : \n" + xmlHashIds);
-    System.out.println("\nJSON document Generated XML Event Pre Hashes : \n" + jsonHashIds);
     assertEquals(xmlHashIds, jsonHashIds);
   }
 
@@ -251,14 +246,7 @@ public class EventHashGeneratorPublisherTest {
     EventHashGenerator.prehashJoin("\\n");
     final Multi<Map<String, String>> eventHashIds =
         EventHashGenerator.fromJson(jsonStream, "prehash", "sha3-512");
-
-    eventHashIds
-        .subscribe()
-        .with(
-            jsonHash ->
-                System.out.println(jsonHash.get("prehash") + "\n" + jsonHash.get("sha3-512")),
-            failure -> System.out.println("XML HashId Generation Failed with " + failure),
-            () -> System.out.println("Completed"));
+    assertEquals(1, eventHashIds.subscribe().asStream().toList().size());
   }
 
   @Test
@@ -268,13 +256,22 @@ public class EventHashGeneratorPublisherTest {
     EventHashGenerator.prehashJoin("\\n");
     final Multi<Map<String, String>> eventHashIds =
         EventHashGenerator.fromJson(jsonStream, "prehash", "sha3-512");
+    assertEquals(1, eventHashIds.subscribe().asStream().toList().size());
+  }
 
-    eventHashIds
-        .subscribe()
-        .with(
+  @Test
+  public void bizTransactionOrderTest() throws IOException {
+    final InputStream jsonStream = getClass().getResourceAsStream("/bizTransactionOrder.json");
+    EventHashGenerator.prehashJoin("\\n");
+    final Multi<Map<String, String>> eventHashIds =
+        EventHashGenerator.fromJson(jsonStream, "prehash", "sha3-512");
+    assertEquals(1, eventHashIds.subscribe().asStream().toList().size());
+    /*eventHashIds
+    .subscribe()
+    .with(
             jsonHash ->
-                System.out.println(jsonHash.get("prehash") + "\n" + jsonHash.get("sha3-512")),
+                    System.out.println(jsonHash.get("prehash") + "\n" + jsonHash.get("sha3-512")),
             failure -> System.out.println("XML HashId Generation Failed with " + failure),
-            () -> System.out.println("Completed"));
+            () -> System.out.println("Completed"));*/
   }
 }

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -266,12 +266,5 @@ public class EventHashGeneratorPublisherTest {
     final Multi<Map<String, String>> eventHashIds =
         EventHashGenerator.fromJson(jsonStream, "prehash", "sha3-512");
     assertEquals(1, eventHashIds.subscribe().asStream().toList().size());
-    /*eventHashIds
-    .subscribe()
-    .with(
-            jsonHash ->
-                    System.out.println(jsonHash.get("prehash") + "\n" + jsonHash.get("sha3-512")),
-            failure -> System.out.println("XML HashId Generation Failed with " + failure),
-            () -> System.out.println("Completed"));*/
   }
 }

--- a/core/src/test/resources/bizTransactionOrder.json
+++ b/core/src/test/resources/bizTransactionOrder.json
@@ -1,0 +1,60 @@
+{
+  "@context": "https://ref.gs1.org/standards/epcis/2.0.0/epcis-context.jsonld",
+  "id": "_:document1",
+  "type": "EPCISDocument",
+  "schemaVersion": "2.0",
+  "creationDate": "2005-07-11T11:30:47.0Z",
+  "epcisBody": {
+    "eventList": [
+      {
+        "type": "ObjectEvent",
+        "action": "OBSERVE",
+        "bizStep": "shipping",
+        "disposition": "in_transit",
+        "epcList": [
+          "urn:epc:id:sgtin:0614141.107346.2017",
+          "urn:epc:id:sgtin:0614141.107346.2018"
+        ],
+        "eventTime": "2005-04-03T20:33:31.116000-06:00",
+        "eventTimeZoneOffset": "-06:00",
+        "readPoint": {
+          "id": "urn:epc:id:sgln:0614141.07346.1234"
+        },
+        "bizTransactionList": [
+          {
+            "type": "po",
+            "bizTransaction": "http://transaction.acme.com/po/12345678"
+          }
+        ],
+        "sourceList": [
+          {
+            "type": "location",
+            "source": "urn:epc:id:sgln:4012345.00225.0"
+          },
+          {
+            "type": "possessing_party",
+            "source": "urn:epc:id:pgln:4012345.00225"
+          },
+          {
+            "type": "owning_party",
+            "source": "urn:epc:id:pgln:4012345.00225"
+          }
+        ],
+        "destinationList": [
+          {
+            "type": "location",
+            "destination": "urn:epc:id:sgln:0614141.00777.0"
+          },
+          {
+            "type": "possessing_party",
+            "destination": "urn:epc:id:pgln:0614141.00777"
+          },
+          {
+            "type": "owning_party",
+            "destination": "urn:epc:id:pgln:0614141.00777"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR along with the PR (https://github.com/openepcis/openepcis-epc-digitallink-translator/pull/3) created in [openepcis-epc-digitallink-translator](https://github.com/openepcis/openepcis-epc-digitallink-translator) project will fix the issue: https://github.com/openepcis/openepcis-event-hash-generator/issues/7

This PR will fix the ordering of the elements in `bizTransaction`, `source` and `destination`. It will also use the latest changes in [openepcis-epc-digitallink-translator](https://github.com/openepcis/openepcis-epc-digitallink-translator) project by using the latest 0.9.2-SNAPSHOT version.

Kindly request you to review the changes and approve the pull request.