### PR TITLE
remove the sensorElementList during the userExtensions prehash buildi…

### DIFF
--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -20,7 +20,6 @@ import static io.openepcis.epc.eventhash.constant.ConstantEventHashInfo.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.openepcis.constants.EPCIS;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.util.ConverterUtil;
 import java.time.Instant;
 import java.util.*;
@@ -302,6 +301,7 @@ public class ContextNode {
     } else {
 
       if (getName() != null
+          && !getName().equals(EPCIS.SENSOR_ELEMENT_LIST)
           && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
           && !EXCLUDE_FIELDS_IN_PREHASH.contains(getName())
           && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)
@@ -380,8 +380,7 @@ public class ContextNode {
       // bareString values then convert them to WebURI
       return name
           + "="
-          + ConverterUtil.toCbvVocabulary(
-              value, findParent(currentNode), Constants.WEBURI_FORMATTED);
+          + ConverterUtil.toCbvVocabulary(value, findParent(currentNode), EPCIS.WEBURI);
     } else if (SOURCE_DESTINATION_URN_PREFIX.stream().anyMatch(value::startsWith)) {
       // If the field is of Source/Destination SGLN type then convert the value from URN to WebURI.
       return name + "=" + ConverterUtil.toURI(value);

--- a/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
@@ -15,10 +15,11 @@
  */
 package io.openepcis.epc.eventhash.constant;
 
+import static io.openepcis.constants.EPCIS.GS1_CBV_DOMAIN;
+import static io.openepcis.constants.EPCIS.GS1_VOC_DOMAIN;
 import static java.util.Map.entry;
 
 import io.openepcis.constants.EPCIS;
-import io.openepcis.epc.translator.constants.Constants;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.HashMap;
@@ -171,8 +172,8 @@ public class ConstantEventHashInfo {
     BARE_STRING_FIELD_PARENT_CHILD.put(EPCIS.SOURCE_LIST, EPCIS.TYPE);
     BARE_STRING_FIELD_PARENT_CHILD.put(EPCIS.DESTINATION_LIST, EPCIS.TYPE);
 
-    SENSOR_REPORT_FORMAT.put(EPCIS.TYPE, Constants.GS1_VOC_DOMAIN);
-    SENSOR_REPORT_FORMAT.put(EPCIS.EXCEPTION, Constants.GS1_VOC_DOMAIN);
-    SENSOR_REPORT_FORMAT.put(EPCIS.COMPONENT, Constants.GS1_CBV_DOMAIN + "Comp-");
+    SENSOR_REPORT_FORMAT.put(EPCIS.TYPE, GS1_VOC_DOMAIN);
+    SENSOR_REPORT_FORMAT.put(EPCIS.EXCEPTION, GS1_VOC_DOMAIN);
+    SENSOR_REPORT_FORMAT.put(EPCIS.COMPONENT, GS1_CBV_DOMAIN + "Comp-");
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
@@ -15,8 +15,6 @@
  */
 package io.openepcis.epc.eventhash.constant;
 
-import static io.openepcis.constants.EPCIS.GS1_CBV_DOMAIN;
-import static io.openepcis.constants.EPCIS.GS1_VOC_DOMAIN;
 import static java.util.Map.entry;
 
 import io.openepcis.constants.EPCIS;
@@ -92,8 +90,8 @@ public class ConstantEventHashInfo {
   public static final List<String> EXCLUDE_XML_FIELDS =
       List.of(
           EPCIS.EPCIS_DOCUMENT_WITH_NAMESPACE,
-          EPCIS.EPCIS_BODY_IN_UPPER_CASE,
-          EPCIS.EVENT_LIST_IN_UPPER_CASE);
+          EPCIS.EPCIS_BODY_IN_CAMEL_CASE,
+          EPCIS.EVENT_LIST_IN_CAMEL_CASE);
   public static final List<String> WHAT_DIMENSION_XML_PATH =
       List.of(
           EPCIS.EPC + EPCIS.PATH_DELIMITER + EPCIS.EPC_LIST + EPCIS.PATH_DELIMITER,
@@ -172,8 +170,8 @@ public class ConstantEventHashInfo {
     BARE_STRING_FIELD_PARENT_CHILD.put(EPCIS.SOURCE_LIST, EPCIS.TYPE);
     BARE_STRING_FIELD_PARENT_CHILD.put(EPCIS.DESTINATION_LIST, EPCIS.TYPE);
 
-    SENSOR_REPORT_FORMAT.put(EPCIS.TYPE, GS1_VOC_DOMAIN);
-    SENSOR_REPORT_FORMAT.put(EPCIS.EXCEPTION, GS1_VOC_DOMAIN);
-    SENSOR_REPORT_FORMAT.put(EPCIS.COMPONENT, GS1_CBV_DOMAIN + "Comp-");
+    SENSOR_REPORT_FORMAT.put(EPCIS.TYPE, EPCIS.GS1_VOC_DOMAIN);
+    SENSOR_REPORT_FORMAT.put(EPCIS.EXCEPTION, EPCIS.GS1_VOC_DOMAIN);
+    SENSOR_REPORT_FORMAT.put(EPCIS.COMPONENT, EPCIS.GS1_CBV_DOMAIN + "Comp-");
   }
 }


### PR DESCRIPTION
Currently during the creation of pre-hash string with sensor data containing the user extensions there are 2 `sensorElementList` is added to pre-hash string. As per the confirmation from Ralph this is not standard approach. This PR will fix the issue of adding the `sensorElementList` to user extensions pre-hash. Kindly request you to review the PR and merge.