### PR TITLE
Adding support for event hash generation for XML and JSON EPCISQueryDocument

### DIFF
--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -237,7 +237,8 @@ public class EventHashGenerator {
       final Map<String, String> contextHeader,
       final String... hashAlgorithms) {
     addToContextHeader(objectNode, contextHeader);
-    if (!objectNode.get(EPCIS.TYPE).asText().equalsIgnoreCase(EPCIS.EPCIS_DOCUMENT)) {
+    if (!objectNode.get(EPCIS.TYPE).asText().equalsIgnoreCase(EPCIS.EPCIS_DOCUMENT)
+        && !objectNode.get(EPCIS.TYPE).asText().equalsIgnoreCase(EPCIS.EPCIS_QUERY_DOCUMENT)) {
       final ContextNode contextNode = new ContextNode(objectNode.fields(), contextHeader);
       final String preHashString = contextNode.toShortenedString();
 

--- a/core/src/main/java/io/openepcis/epc/eventhash/publisher/ObjectNodeUtil.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/publisher/ObjectNodeUtil.java
@@ -15,6 +15,8 @@
  */
 package io.openepcis.epc.eventhash.publisher;
 
+import static io.openepcis.constants.EPCIS.*;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Arrays;
 import java.util.List;
@@ -25,7 +27,7 @@ import lombok.NoArgsConstructor;
 public class ObjectNodeUtil {
 
   protected static final List<String> REQUIRED_DOCUMENT_FIELDS =
-      Arrays.asList("@context", "type", "schemaVersion", "creationDate");
+      Arrays.asList(CONTEXT, TYPE, SCHEMA_VERSION, CREATION_DATE);
 
   public static boolean isValidEPCISDocumentNode(final ObjectNode header) {
     for (String field : REQUIRED_DOCUMENT_FIELDS) {

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -22,7 +22,6 @@ import io.smallrye.mutiny.Multi;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,7 @@ public class EventHashGeneratorPublisherTest {
   private EventHashGenerator eventHashGenerator;
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     eventHashGenerator = new EventHashGenerator();
   }
 
@@ -219,7 +218,7 @@ public class EventHashGeneratorPublisherTest {
   }
 
   @Test
-  public void withUserExtensionsHavingEventID() throws IOException, URISyntaxException {
+  public void withUserExtensionsHavingEventID() throws IOException {
     // For same event in XML & JSON format check if the generated Hash-IDs match.
     final InputStream xmlStream =
         getClass()
@@ -448,5 +447,227 @@ public class EventHashGeneratorPublisherTest {
     assertEquals(
         xmlEventHash.subscribe().asStream().toList(),
         jsonEventHash.subscribe().asStream().toList());
+  }
+
+  // Compare EPCIS Document with EPCIS Query Document
+  @Test
+  public void combinationJSONQueryDocumentTest() throws IOException {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "2.0/EPCIS/JSON/Capture/Documents/Combination_of_different_event.json");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Query/Combination_of_different_event.json");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromJson(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromJson(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
+    // documentEventHash.subscribe().with(dHash -> System.out.println(dHash.get("sha-256") + "\n" +
+    // dHash.get("prehash") + "\n\n"), failure -> System.out.println("Document HashId Generation
+    // Failed with " + failure));
+  }
+
+  @Test
+  public void curieJSONQueryDocumentTest() throws IOException {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/CurieString_document.json");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Query/CurieString_document.json");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromJson(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromJson(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void jumbledJSONOrderQueryDocumentTest() throws IOException {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/JumbledFieldsOrder.json");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Query/JumbledFieldsOrder.json");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromJson(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromJson(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void sensorDataJSONnQueryDocumentTest() throws IOException {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "2.0/EPCIS/JSON/Capture/Documents/SensorData_with_combined_events.json");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Query/SensorData_with_combined_events.json");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromJson(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromJson(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void errorDeclarationJSONQueryDocumentTest() throws IOException {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_with_errorDeclaration.json");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "2.0/EPCIS/JSON/Query/TransformationEvent_with_errorDeclaration.json");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromJson(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromJson(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void combinationXMLQueryDocumentTest() {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "2.0/EPCIS/XML/Capture/Documents/Combination_of_different_event.xml");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Query/Combination_of_different_event.xml");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromXml(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromXml(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void curieXMLQueryDocumentTest() {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Capture/Documents/CurieString_document.xml");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Query/CurieString_document.xml");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromXml(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromXml(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void jumbledXMLOrderQueryDocumentTest() {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Capture/Documents/JumbledFieldsOrder.xml");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Query/JumbledFieldsOrder.xml");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromXml(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromXml(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void sensorDataXMLQueryDocumentTest() {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "2.0/EPCIS/XML/Capture/Documents/SensorData_with_combined_events.xml");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Query/SensorData_with_combined_events.xml");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromXml(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromXml(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void errorDeclarationXMLQueryDocumentTest() {
+    final InputStream epcisDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "2.0/EPCIS/XML/Capture/Documents/TransformationEvent_with_errorDeclaration.xml");
+    final InputStream epcisQueryDocument =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "2.0/EPCIS/XML/Query/TransformationEvent_with_errorDeclaration.xml");
+
+    final Multi<Map<String, String>> documentEventHash =
+        eventHashGenerator.fromXml(epcisDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+        eventHashGenerator.fromXml(epcisQueryDocument, "prehash", "sha-256");
+
+    assertEquals(
+        documentEventHash.subscribe().asStream().toList(),
+        queryEventHash.subscribe().asStream().toList());
   }
 }


### PR DESCRIPTION
@sboeckelmann 

Previously, the tool only supported generating event hashes for EPCISDocument. However, I have now added support for generating event hashes for EPCISQueryDocument, which is also being implemented in the Python tool. 

Could you please review the code and approve the pull request. Thank you.