### PR TITLE
Adding REST Assured based TC's to Event Hash Generator API endpoints

### DIFF
--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/quarkus-app/src/test/java/io/openecpis/epc/eventhash/generator/rest/CompareApiResultsTest.java
+++ b/quarkus-app/src/test/java/io/openecpis/epc/eventhash/generator/rest/CompareApiResultsTest.java
@@ -79,8 +79,7 @@ public class CompareApiResultsTest {
     };
   }
 
-  // Compare Event Hash generated for XML and JSON document.
-  // Parameterized test to compare event hash for XML and JSON documents
+  // Parameterized test to compare event hash for XML and JSON EPCIS documents
   @org.testng.annotations.Test(dataProvider = "documentTestData")
   public void compareDocumentEventHashTest(final String xmlFilePath, final String jsonFilePath)
       throws IOException {
@@ -108,8 +107,7 @@ public class CompareApiResultsTest {
     xmlResponse.then().body(equalTo(jsonResponse.getBody().asString()));
   }
 
-  // Compare Event Hash generated for XML and JSON document.
-  // Parameterized test to compare event hash for XML and JSON documents
+  // Parameterized test to compare event hash for XML and JSON EPCIS events
   @org.testng.annotations.Test(dataProvider = "eventTestData")
   public void compareEventsListEventHashTest(final String xmlFilePath, final String jsonFilePath)
       throws IOException {
@@ -124,6 +122,7 @@ public class CompareApiResultsTest {
             .when()
             .post(eventListEventHashAPI);
 
+    // Add the wrapper array for EPCIS events
     final ArrayNode jsonArray = objectMapper.createArrayNode();
     final ObjectNode objectNode =
         (ObjectNode)

--- a/quarkus-app/src/test/java/io/openecpis/epc/eventhash/generator/rest/CompareApiResultsTest.java
+++ b/quarkus-app/src/test/java/io/openecpis/epc/eventhash/generator/rest/CompareApiResultsTest.java
@@ -1,0 +1,141 @@
+package io.openecpis.epc.eventhash.generator.rest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.DataProvider;
+
+public class CompareApiResultsTest {
+
+  private String documentEventHashAPI;
+  private String eventListEventHashAPI;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeSuite
+  public void beforeEachTestMethod() {
+    int port =
+        ConfigProviderResolver.instance()
+            .getConfig()
+            .getOptionalValue("quarkus.http.port", Integer.class)
+            .orElse(8080);
+
+    final String basePath = "http://localhost:" + port;
+    documentEventHashAPI = basePath + "/api/generate/event-hash/document";
+    eventListEventHashAPI = basePath + "/api/generate/event-hash/events";
+  }
+
+  @DataProvider(name = "documentTestData")
+  public Object[][] documentTestData() {
+    return new Object[][] {
+      {
+        "2.0/EPCIS/XML/Capture/Documents/AggregationEvent.xml",
+        "2.0/EPCIS/JSON/Capture/Documents/AggregationEvent.json"
+      },
+      {
+        "2.0/EPCIS/XML/Capture/Documents/Combination_of_different_event.xml",
+        "2.0/EPCIS/JSON/Capture/Documents/Combination_of_different_event.json"
+      },
+      {
+        "2.0/EPCIS/XML/Capture/Documents/SensorData_with_combined_events.xml",
+        "2.0/EPCIS/JSON/Capture/Documents/SensorData_with_combined_events.json"
+      },
+      {
+        "2.0/EPCIS/XML/Capture/Documents/TransformationEvent.xml",
+        "2.0/EPCIS/JSON/Capture/Documents/TransformationEvent.json"
+      },
+      {
+        "2.0/EPCIS/XML/Capture/Documents/Namespaces_at_different_level.xml",
+        "2.0/EPCIS/JSON/Capture/Documents/Namespaces_at_different_level.json"
+      }
+    };
+  }
+
+  @DataProvider(name = "eventTestData")
+  public Object[][] eventsTestData() {
+    return new Object[][] {
+      {
+        "2.0/EPCIS/XML/Capture/Events/AggregationEvent.xml",
+        "2.0/EPCIS/JSON/Capture/Events/AggregationEvent.json"
+      },
+      {
+        "2.0/EPCIS/XML/Capture/Events/AssociationEvent.xml",
+        "2.0/EPCIS/JSON/Capture/Events/AssociationEvent.json"
+      },
+      {
+        "2.0/EPCIS/XML/Capture/Events/TransformationEvent.xml",
+        "2.0/EPCIS/JSON/Capture/Events/TransformationEvent.json"
+      }
+    };
+  }
+
+  // Compare Event Hash generated for XML and JSON document.
+  // Parameterized test to compare event hash for XML and JSON documents
+  @org.testng.annotations.Test(dataProvider = "documentTestData")
+  public void compareDocumentEventHashTest(final String xmlFilePath, final String jsonFilePath)
+      throws IOException {
+    final Response xmlResponse =
+        given()
+            .header("Content-Type", "application/xml")
+            .body(
+                IOUtils.toString(
+                    Objects.requireNonNull(
+                        getClass().getClassLoader().getResourceAsStream(xmlFilePath)),
+                    StandardCharsets.UTF_8))
+            .when()
+            .post(documentEventHashAPI);
+
+    final Response jsonResponse =
+        given()
+            .contentType(ContentType.JSON)
+            .body(getClass().getClassLoader().getResourceAsStream(jsonFilePath))
+            .when()
+            .post(documentEventHashAPI);
+
+    // Compare response bodies
+    xmlResponse.then().statusCode(200);
+    jsonResponse.then().statusCode(200);
+    xmlResponse.then().body(equalTo(jsonResponse.getBody().asString()));
+  }
+
+  // Compare Event Hash generated for XML and JSON document.
+  // Parameterized test to compare event hash for XML and JSON documents
+  @org.testng.annotations.Test(dataProvider = "eventTestData")
+  public void compareEventsListEventHashTest(final String xmlFilePath, final String jsonFilePath)
+      throws IOException {
+    final Response xmlResponse =
+        given()
+            .contentType(ContentType.XML)
+            .body(
+                IOUtils.toString(
+                    Objects.requireNonNull(
+                        getClass().getClassLoader().getResourceAsStream(xmlFilePath)),
+                    StandardCharsets.UTF_8))
+            .when()
+            .post(eventListEventHashAPI);
+
+    final ArrayNode jsonArray = objectMapper.createArrayNode();
+    final ObjectNode objectNode =
+        (ObjectNode)
+            objectMapper.readTree(getClass().getClassLoader().getResourceAsStream(jsonFilePath));
+    jsonArray.add(objectNode);
+
+    final Response jsonResponse =
+        given().contentType(ContentType.JSON).body(jsonArray).when().post(eventListEventHashAPI);
+
+    // Compare response bodies
+    xmlResponse.then().statusCode(200);
+    jsonResponse.then().statusCode(200);
+    xmlResponse.then().body(equalTo(jsonResponse.getBody().asString()));
+  }
+}

--- a/quarkus-app/src/test/java/io/openecpis/epc/eventhash/generator/rest/RestEndpointTest.java
+++ b/quarkus-app/src/test/java/io/openecpis/epc/eventhash/generator/rest/RestEndpointTest.java
@@ -15,31 +15,129 @@
  */
 package io.openecpis.epc.eventhash.generator.rest;
 
+import static io.restassured.RestAssured.given;
+import static org.junit.Assert.assertEquals;
+
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.resteasy.reactive.RestResponse;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 
 @QuarkusTest
 public class RestEndpointTest {
   // NOTE: RestAssured is aware of the application.properties quarkus.http.root-path switch
 
+  private String basePath;
+  private String documentEventHashAPI;
+
+  @Before
+  public void testApiEndpoint() {
+    int port =
+        ConfigProviderResolver.instance()
+            .getConfig()
+            .getOptionalValue("quarkus.http.port", Integer.class)
+            .orElse(8080);
+
+    basePath = "http://localhost:" + port;
+    documentEventHashAPI = basePath + "/api/generate/event-hash/document";
+  }
+
   @Test
-  public void testSwaggerUI() {
+  public void swaggerUITest() {
     RestAssured.when()
-        .get("/q/swagger-ui/index.html")
+        .get(basePath + "/q/swagger-ui/index.html")
         .then()
         .statusCode(RestResponse.StatusCode.OK);
   }
 
   @Test
-  public void testDocuments() {
+  public void documentsTest() {
     RestAssured.given()
         .contentType("application/json")
         .accept("application/json")
         .body(getClass().getResourceAsStream("/SensorDataExample.json"))
-        .post("/api/generate/event-hash/document")
+        .post(basePath + "/api/generate/event-hash/document")
         .then()
         .statusCode(RestResponse.StatusCode.OK);
+  }
+
+  // Status code test for JSON input
+  @Test
+  public void generateJsonDocumentEventHashStatusCodeTest() {
+    given()
+        .contentType(ContentType.JSON)
+        .body(
+            getClass()
+                .getClassLoader()
+                .getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/AggregationEvent.json"))
+        .when()
+        .post(documentEventHashAPI)
+        .then()
+        .statusCode(200);
+  }
+
+  // Invalid Request type for JSON input
+  @Test
+  public void generateJsonEventHashInvalidRequestTypeTest() {
+    final Response jsonResponse =
+        given()
+            .contentType(ContentType.XML)
+            .body(
+                getClass()
+                    .getClassLoader()
+                    .getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/AggregationEvent.json"))
+            .when()
+            .post(documentEventHashAPI);
+
+    assertEquals(500, jsonResponse.statusCode());
+    assertEquals("Content is not allowed in prolog.", jsonResponse.jsonPath().get("detail"));
+  }
+
+  // Invalid Request type for XML input
+  @Test
+  public void generateXmlEventHashInvalidRequestTypeTest() throws IOException {
+    final Response xmlResponse =
+        given()
+            .contentType(ContentType.JSON)
+            .body(
+                IOUtils.toString(
+                    Objects.requireNonNull(
+                        getClass()
+                            .getClassLoader()
+                            .getResourceAsStream(
+                                "2.0/EPCIS/XML/Capture/Documents/AggregationEvent.xml")),
+                    StandardCharsets.UTF_8))
+            .when()
+            .post(documentEventHashAPI);
+
+    assertEquals(500, xmlResponse.statusCode());
+    assertEquals("JsonParseException", xmlResponse.jsonPath().get("type"));
+  }
+
+  // Status code test for XML input
+  @Test
+  public void generateXmlEventHashStatusCodeTest() throws IOException {
+    given()
+        .contentType(ContentType.XML)
+        .body(
+            IOUtils.toString(
+                Objects.requireNonNull(
+                    getClass()
+                        .getClassLoader()
+                        .getResourceAsStream(
+                            "2.0/EPCIS/XML/Capture/Documents/AggregationEvent.xml")),
+                StandardCharsets.UTF_8))
+        .when()
+        .post(documentEventHashAPI)
+        .then()
+        .statusCode(200);
   }
 }

--- a/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
+++ b/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
@@ -166,7 +166,7 @@ public class EventHashGeneratorResource {
     // Add the Hash Algorithm type to the List.
     hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
-    return (contentType.equals("application/xml")
+    return (contentType.contains("application/xml")
             ? eventHashGenerator.fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))
             : eventHashGenerator.fromJson(
                 inputDocumentStream, hashParameters.toArray(String[]::new)))
@@ -284,7 +284,7 @@ public class EventHashGeneratorResource {
     // Add the Hash Algorithm type to the List.
     hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
-    return (contentType.equals("application/xml")
+    return (contentType.contains("application/xml")
             ? eventHashGenerator.fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))
             : eventHashGenerator.fromJson(
                 generateJsonDocumentWrapper(inputDocumentStream),


### PR DESCRIPTION
@sboeckelmann 

This PR contains the feature to include REST-assured TCs for Event Hash Generator API endpoints. Please let me know if we need to include more TCs or need to cover any particular scenarios for the API testing.

Please review and approve the PR.