### PR TITLE
Option to ignore repository specific fields

### DIFF
--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -237,7 +237,7 @@ public class ContextNode {
         && node.getChildren() != null
         && !node.getChildren().isEmpty()
         && node.getChildren().get(0).getName() == null
-        && CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream().noneMatch(getName()::equals)) {
+        && FIELDS_TO_EXCLUDE_IN_PREHASH.stream().noneMatch(getName()::equals)) {
       fieldName = node.getName();
     }
 
@@ -292,7 +292,7 @@ public class ContextNode {
         && getName() != null
         && getValue() != null
         && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
-        && !CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.contains(getName())
+        && !FIELDS_TO_EXCLUDE_IN_PREHASH.contains(getName())
         && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)) {
       // Add information related to direct name and value based fields. Then if attributes are
       // present then call the method to format them.
@@ -302,7 +302,7 @@ public class ContextNode {
       if (getName() != null
           && !getName().equals(EPCIS.SENSOR_ELEMENT_LIST)
           && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
-          && !CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.contains(getName())
+          && !FIELDS_TO_EXCLUDE_IN_PREHASH.contains(getName())
           && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)
           && (getName().equals(EPCIS.SENSOR_ELEMENT)
               || (!children.isEmpty()
@@ -334,7 +334,7 @@ public class ContextNode {
       final String name, final String value, final ContextNode currentNode) {
     // If the field matches to ignore field then do not include them within the event pre hash. Ex:
     // recordTime
-    if (CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream().anyMatch(name::startsWith)) {
+    if (FIELDS_TO_EXCLUDE_IN_PREHASH.stream().anyMatch(name::startsWith)) {
       return null;
     }
 

--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -20,6 +20,7 @@ import static io.openepcis.epc.eventhash.constant.ConstantEventHashInfo.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.openepcis.constants.EPCIS;
+import io.openepcis.epc.eventhash.constant.ConstantEventHashInfo;
 import io.openepcis.epc.translator.util.ConverterUtil;
 import java.time.Instant;
 import java.util.*;
@@ -237,7 +238,8 @@ public class ContextNode {
         && node.getChildren() != null
         && !node.getChildren().isEmpty()
         && node.getChildren().get(0).getName() == null
-        && FIELDS_TO_EXCLUDE_IN_PREHASH.stream().noneMatch(getName()::equals)) {
+        && ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().stream()
+            .noneMatch(getName()::equals)) {
       fieldName = node.getName();
     }
 
@@ -292,7 +294,7 @@ public class ContextNode {
         && getName() != null
         && getValue() != null
         && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
-        && !FIELDS_TO_EXCLUDE_IN_PREHASH.contains(getName())
+        && !ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(getName())
         && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)) {
       // Add information related to direct name and value based fields. Then if attributes are
       // present then call the method to format them.
@@ -302,7 +304,7 @@ public class ContextNode {
       if (getName() != null
           && !getName().equals(EPCIS.SENSOR_ELEMENT_LIST)
           && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
-          && !FIELDS_TO_EXCLUDE_IN_PREHASH.contains(getName())
+          && !ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(getName())
           && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)
           && (getName().equals(EPCIS.SENSOR_ELEMENT)
               || (!children.isEmpty()
@@ -334,7 +336,8 @@ public class ContextNode {
       final String name, final String value, final ContextNode currentNode) {
     // If the field matches to ignore field then do not include them within the event pre hash. Ex:
     // recordTime
-    if (FIELDS_TO_EXCLUDE_IN_PREHASH.stream().anyMatch(name::startsWith)) {
+    if (ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().stream()
+        .anyMatch(name::startsWith)) {
       return null;
     }
 

--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -162,7 +162,6 @@ public class ContextNode {
   // Private method to return the Strings from well known EPCIS fields/attributes of EPCIS event
   // such as type, eventTime, bizStep etc. by omitting the User-Extensions.
   private String epcisFieldsPreHashBuilder() {
-
     // Check if the elements are of root elements and do not contain the children elements. If the
     // element is part of EPCIS standard fields then append to pre-hash string.
     if (children.isEmpty()
@@ -238,7 +237,7 @@ public class ContextNode {
         && node.getChildren() != null
         && !node.getChildren().isEmpty()
         && node.getChildren().get(0).getName() == null
-        && EXCLUDE_FIELDS_IN_PREHASH.stream().noneMatch(getName()::equals)) {
+        && CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream().noneMatch(getName()::equals)) {
       fieldName = node.getName();
     }
 
@@ -293,7 +292,7 @@ public class ContextNode {
         && getName() != null
         && getValue() != null
         && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
-        && !EXCLUDE_FIELDS_IN_PREHASH.contains(getName())
+        && !CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.contains(getName())
         && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)) {
       // Add information related to direct name and value based fields. Then if attributes are
       // present then call the method to format them.
@@ -303,7 +302,7 @@ public class ContextNode {
       if (getName() != null
           && !getName().equals(EPCIS.SENSOR_ELEMENT_LIST)
           && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
-          && !EXCLUDE_FIELDS_IN_PREHASH.contains(getName())
+          && !CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.contains(getName())
           && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)
           && (getName().equals(EPCIS.SENSOR_ELEMENT)
               || (!children.isEmpty()
@@ -335,7 +334,7 @@ public class ContextNode {
       final String name, final String value, final ContextNode currentNode) {
     // If the field matches to ignore field then do not include them within the event pre hash. Ex:
     // recordTime
-    if (EXCLUDE_FIELDS_IN_PREHASH.stream().anyMatch(name::startsWith)) {
+    if (CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream().anyMatch(name::startsWith)) {
       return null;
     }
 

--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -18,16 +18,14 @@ package io.openepcis.epc.eventhash;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openepcis.constants.EPCIS;
+import io.openepcis.epc.eventhash.constant.ConstantEventHashInfo;
 import io.openepcis.epc.eventhash.exception.EventHashException;
 import io.openepcis.reactive.publisher.ObjectNodePublisher;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Consumer;
 import javax.xml.parsers.SAXParserFactory;
 import lombok.NoArgsConstructor;
@@ -37,7 +35,6 @@ import org.reactivestreams.Publisher;
 @Slf4j
 @NoArgsConstructor
 public class EventHashGenerator {
-
   private static final SAXParserFactory SAX_PARSER_FACTORY = SAXParserFactory.newInstance();
   private String prehashJoin = "";
 
@@ -51,6 +48,23 @@ public class EventHashGenerator {
 
   public void prehashJoin(final String s) {
     prehashJoin = s.replace("\\n", "\n").replace("\\r", "\r");
+  }
+
+  /**
+   * Method used to populate custom fields that needs to be ignored during the pre-hash generation
+   *
+   * @param ignoreFieldsForHash List of string element with field name which will be ignored during
+   *     the pre-hash generation.
+   */
+  public void customFieldsToIgnore(final String ignoreFieldsForHash) {
+    final List<String> ignoreFieldsList =
+        Arrays.stream(ignoreFieldsForHash.split(",")).map(String::trim).toList();
+
+    // Clear the existing element if any
+    ConstantEventHashInfo.clearFieldsToExclude();
+
+    // Add the provided elements to List which will be ignored during pre-hash generation
+    ConstantEventHashInfo.addFieldsToExclude(ignoreFieldsList);
   }
 
   /**

--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -53,18 +53,18 @@ public class EventHashGenerator {
   /**
    * Method used to populate custom fields that needs to be ignored during the pre-hash generation
    *
-   * @param ignoreFieldsForHash List of string element with field name which will be ignored during
-   *     the pre-hash generation.
+   * @param excludeFields List of string element with field name which will be ignored during the
+   *     pre-hash generation.
    */
-  public void customFieldsToIgnore(final String ignoreFieldsForHash) {
-    final List<String> ignoreFieldsList =
-        Arrays.stream(ignoreFieldsForHash.split(",")).map(String::trim).toList();
+  public void excludeFieldsInPreHash(final String excludeFields) {
+    final List<String> excludeFieldsList =
+        Arrays.stream(excludeFields.split(",")).map(String::trim).toList();
 
     // Clear the existing element if any
     ConstantEventHashInfo.clearFieldsToExclude();
 
     // Add the provided elements to List which will be ignored during pre-hash generation
-    ConstantEventHashInfo.addFieldsToExclude(ignoreFieldsList);
+    ConstantEventHashInfo.addFieldsToExclude(excludeFieldsList);
   }
 
   /**

--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -30,6 +30,7 @@ import java.util.function.Consumer;
 import javax.xml.parsers.SAXParserFactory;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.reactivestreams.Publisher;
 
 @Slf4j
@@ -57,14 +58,17 @@ public class EventHashGenerator {
    *     pre-hash generation.
    */
   public void excludeFieldsInPreHash(final String excludeFields) {
-    final List<String> excludeFieldsList =
-        Arrays.stream(excludeFields.split(",")).map(String::trim).toList();
+    // If user has provided any values then add them to fields which needs to be omitted
+    if (!StringUtils.isBlank(excludeFields)) {
+      final List<String> excludeFieldsList =
+          Arrays.stream(excludeFields.split(",")).map(String::trim).toList();
 
-    // Clear the existing element if any
-    ConstantEventHashInfo.clearFieldsToExclude();
+      // Clear the existing element if any
+      ConstantEventHashInfo.getContext().clearFieldsToExclude();
 
-    // Add the provided elements to List which will be ignored during pre-hash generation
-    ConstantEventHashInfo.addFieldsToExclude(excludeFieldsList);
+      // Add the provided elements to List which will be ignored during pre-hash generation
+      ConstantEventHashInfo.getContext().addFieldsToExclude(excludeFieldsList);
+    }
   }
 
   /**

--- a/core/src/main/java/io/openepcis/epc/eventhash/SaxHandler.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/SaxHandler.java
@@ -47,7 +47,7 @@ public class SaxHandler extends DefaultHandler {
     path.push(qName);
 
     // Ignore the non-required elements such as errorDeclaration, recordTime, etc.
-    if (ConstantEventHashInfo.CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
+    if (ConstantEventHashInfo.FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
         .noneMatch(getXMLPath()::contains)) {
       // Reset attributes for every element
       currentAttributes = new HashMap<>();
@@ -101,7 +101,7 @@ public class SaxHandler extends DefaultHandler {
   @Override
   public void characters(char[] ch, int start, int length) {
     // Ignore the non-required elements such as errorDeclaration, recordTime, etc.
-    if (ConstantEventHashInfo.CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
+    if (ConstantEventHashInfo.FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
         .noneMatch(getXMLPath()::contains)) {
       currentValue.append(ch, start, length);
     }
@@ -109,7 +109,7 @@ public class SaxHandler extends DefaultHandler {
 
   @Override
   public void endElement(final String uri, final String localName, final String qName) {
-    if (ConstantEventHashInfo.CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
+    if (ConstantEventHashInfo.FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
         .noneMatch(getXMLPath()::contains)) {
       // Do not store the values for the fields which needs to be ignored such as EPCISDocument,
       // EPCISBody, etc.
@@ -138,7 +138,7 @@ public class SaxHandler extends DefaultHandler {
 
       // After completing the particular element reading, remove that element from the stack.
       path.pop();
-    } else if (ConstantEventHashInfo.CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
+    } else if (ConstantEventHashInfo.FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
         .anyMatch(getXMLPath()::contains)) {
       path.pop();
     }

--- a/core/src/main/java/io/openepcis/epc/eventhash/SaxHandler.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/SaxHandler.java
@@ -47,7 +47,7 @@ public class SaxHandler extends DefaultHandler {
     path.push(qName);
 
     // Ignore the non-required elements such as errorDeclaration, recordTime, etc.
-    if (ConstantEventHashInfo.EXCLUDE_FIELDS_IN_PREHASH.stream()
+    if (ConstantEventHashInfo.CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
         .noneMatch(getXMLPath()::contains)) {
       // Reset attributes for every element
       currentAttributes = new HashMap<>();
@@ -101,7 +101,7 @@ public class SaxHandler extends DefaultHandler {
   @Override
   public void characters(char[] ch, int start, int length) {
     // Ignore the non-required elements such as errorDeclaration, recordTime, etc.
-    if (ConstantEventHashInfo.EXCLUDE_FIELDS_IN_PREHASH.stream()
+    if (ConstantEventHashInfo.CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
         .noneMatch(getXMLPath()::contains)) {
       currentValue.append(ch, start, length);
     }
@@ -109,7 +109,7 @@ public class SaxHandler extends DefaultHandler {
 
   @Override
   public void endElement(final String uri, final String localName, final String qName) {
-    if (ConstantEventHashInfo.EXCLUDE_FIELDS_IN_PREHASH.stream()
+    if (ConstantEventHashInfo.CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
         .noneMatch(getXMLPath()::contains)) {
       // Do not store the values for the fields which needs to be ignored such as EPCISDocument,
       // EPCISBody, etc.
@@ -138,7 +138,7 @@ public class SaxHandler extends DefaultHandler {
 
       // After completing the particular element reading, remove that element from the stack.
       path.pop();
-    } else if (ConstantEventHashInfo.EXCLUDE_FIELDS_IN_PREHASH.stream()
+    } else if (ConstantEventHashInfo.CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
         .anyMatch(getXMLPath()::contains)) {
       path.pop();
     }

--- a/core/src/main/java/io/openepcis/epc/eventhash/SaxHandler.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/SaxHandler.java
@@ -38,6 +38,7 @@ public class SaxHandler extends DefaultHandler {
   private ContextNode rootNode = null;
   private Map<String, String> currentAttributes;
   private final HashMap<String, String> contextHeader = new HashMap<>();
+
   @Setter private MultiEmitter<? super ContextNode> emitter;
 
   @Override
@@ -47,7 +48,7 @@ public class SaxHandler extends DefaultHandler {
     path.push(qName);
 
     // Ignore the non-required elements such as errorDeclaration, recordTime, etc.
-    if (ConstantEventHashInfo.FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
+    if (ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().stream()
         .noneMatch(getXMLPath()::contains)) {
       // Reset attributes for every element
       currentAttributes = new HashMap<>();
@@ -101,7 +102,7 @@ public class SaxHandler extends DefaultHandler {
   @Override
   public void characters(char[] ch, int start, int length) {
     // Ignore the non-required elements such as errorDeclaration, recordTime, etc.
-    if (ConstantEventHashInfo.FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
+    if (ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().stream()
         .noneMatch(getXMLPath()::contains)) {
       currentValue.append(ch, start, length);
     }
@@ -109,7 +110,7 @@ public class SaxHandler extends DefaultHandler {
 
   @Override
   public void endElement(final String uri, final String localName, final String qName) {
-    if (ConstantEventHashInfo.FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
+    if (ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().stream()
         .noneMatch(getXMLPath()::contains)) {
       // Do not store the values for the fields which needs to be ignored such as EPCISDocument,
       // EPCISBody, etc.
@@ -138,7 +139,7 @@ public class SaxHandler extends DefaultHandler {
 
       // After completing the particular element reading, remove that element from the stack.
       path.pop();
-    } else if (ConstantEventHashInfo.FIELDS_TO_EXCLUDE_IN_PREHASH.stream()
+    } else if (ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().stream()
         .anyMatch(getXMLPath()::contains)) {
       path.pop();
     }

--- a/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
@@ -163,7 +163,7 @@ public class ConstantEventHashInfo {
   public static final MultiValuedMap<String, String> BARE_STRING_FIELD_PARENT_CHILD =
       new ArrayListValuedHashMap<>();
 
-  public static final List<String> CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH = new ArrayList<>();
+  public static final List<String> FIELDS_TO_EXCLUDE_IN_PREHASH = new ArrayList<>();
 
   static {
     BARE_STRING_FIELD_PARENT_CHILD.put(EPCIS.BIZ_STEP, EPCIS.BIZ_STEP);
@@ -179,20 +179,20 @@ public class ConstantEventHashInfo {
     SENSOR_REPORT_FORMAT.put(EPCIS.COMPONENT, EPCIS.GS1_CBV_DOMAIN + "Comp-");
 
     // Add default fields
-    CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH);
+    FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH);
   }
 
   public static void addFieldsToExclude(final List<String> fieldsToExclude) {
     // Add all the default fields that's not required in event-hash
-    CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH);
+    FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH);
 
     // Add the user provided fields which needs to be excluded
     if (fieldsToExclude != null && !fieldsToExclude.isEmpty()) {
-      CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(fieldsToExclude);
+      FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(fieldsToExclude);
     }
   }
 
   public static void clearFieldsToExclude() {
-    CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.clear();
+    FIELDS_TO_EXCLUDE_IN_PREHASH.clear();
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
@@ -163,7 +163,8 @@ public class ConstantEventHashInfo {
   public static final MultiValuedMap<String, String> BARE_STRING_FIELD_PARENT_CHILD =
       new ArrayListValuedHashMap<>();
 
-  public static final List<String> FIELDS_TO_EXCLUDE_IN_PREHASH = new ArrayList<>();
+  public final List<String> FIELDS_TO_EXCLUDE_IN_PREHASH =
+      new ArrayList<>(DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH);
 
   static {
     BARE_STRING_FIELD_PARENT_CHILD.put(EPCIS.BIZ_STEP, EPCIS.BIZ_STEP);
@@ -177,12 +178,15 @@ public class ConstantEventHashInfo {
     SENSOR_REPORT_FORMAT.put(EPCIS.TYPE, EPCIS.GS1_VOC_DOMAIN);
     SENSOR_REPORT_FORMAT.put(EPCIS.EXCEPTION, EPCIS.GS1_VOC_DOMAIN);
     SENSOR_REPORT_FORMAT.put(EPCIS.COMPONENT, EPCIS.GS1_CBV_DOMAIN + "Comp-");
-
-    // Add default fields
-    FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH);
   }
 
-  public static void addFieldsToExclude(final List<String> fieldsToExclude) {
+  private static final ConstantEventHashInfo context = new ConstantEventHashInfo();
+
+  public static ConstantEventHashInfo getContext() {
+    return context;
+  }
+
+  public void addFieldsToExclude(final List<String> fieldsToExclude) {
     // Add all the default fields that's not required in event-hash
     FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH);
 
@@ -192,7 +196,11 @@ public class ConstantEventHashInfo {
     }
   }
 
-  public static void clearFieldsToExclude() {
+  public void clearFieldsToExclude() {
     FIELDS_TO_EXCLUDE_IN_PREHASH.clear();
+  }
+
+  public List<String> getFieldsToExcludeInPrehash() {
+    return FIELDS_TO_EXCLUDE_IN_PREHASH;
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/constant/ConstantEventHashInfo.java
@@ -20,6 +20,7 @@ import static java.util.Map.entry;
 import io.openepcis.constants.EPCIS;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,19 +64,20 @@ public class ConstantEventHashInfo {
           EPCIS.BIZ_TRANSACTION_URN_PREFIX,
           EPCIS.SRC_DEST_URN_PREFIX,
           EPCIS.ERROR_REASON_URN_PREFIX);
-  public static final List<String> EXCLUDE_FIELDS_IN_PREHASH =
-      List.of(
-          EPCIS.ERROR_DECLARATION,
-          EPCIS.DECLARATION_TIME,
-          EPCIS.REASON,
-          EPCIS.CORRECTIVE_EVENT_IDS,
-          EPCIS.CORRECTIVE_EVENT_ID,
-          EPCIS.RECORD_TIME,
-          EPCIS.EVENT_ID,
-          EPCIS.CONTEXT,
-          "rdfs:comment",
-          "#text",
-          "comment");
+  public static final List<String> DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH =
+      new ArrayList<>(
+          List.of(
+              EPCIS.ERROR_DECLARATION,
+              EPCIS.DECLARATION_TIME,
+              EPCIS.REASON,
+              EPCIS.CORRECTIVE_EVENT_IDS,
+              EPCIS.CORRECTIVE_EVENT_ID,
+              EPCIS.RECORD_TIME,
+              EPCIS.EVENT_ID,
+              EPCIS.CONTEXT,
+              "rdfs:comment",
+              "#text",
+              "comment"));
   public static final DateTimeFormatter DATE_FORMATTER =
       new DateTimeFormatterBuilder().appendInstant(3).toFormatter();
 
@@ -161,6 +163,8 @@ public class ConstantEventHashInfo {
   public static final MultiValuedMap<String, String> BARE_STRING_FIELD_PARENT_CHILD =
       new ArrayListValuedHashMap<>();
 
+  public static final List<String> CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH = new ArrayList<>();
+
   static {
     BARE_STRING_FIELD_PARENT_CHILD.put(EPCIS.BIZ_STEP, EPCIS.BIZ_STEP);
     BARE_STRING_FIELD_PARENT_CHILD.put(EPCIS.DISPOSITION, EPCIS.DISPOSITION);
@@ -173,5 +177,22 @@ public class ConstantEventHashInfo {
     SENSOR_REPORT_FORMAT.put(EPCIS.TYPE, EPCIS.GS1_VOC_DOMAIN);
     SENSOR_REPORT_FORMAT.put(EPCIS.EXCEPTION, EPCIS.GS1_VOC_DOMAIN);
     SENSOR_REPORT_FORMAT.put(EPCIS.COMPONENT, EPCIS.GS1_CBV_DOMAIN + "Comp-");
+
+    // Add default fields
+    CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH);
+  }
+
+  public static void addFieldsToExclude(final List<String> fieldsToExclude) {
+    // Add all the default fields that's not required in event-hash
+    CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(DEFAULT_FIELDS_TO_EXCLUDE_IN_PREHASH);
+
+    // Add the user provided fields which needs to be excluded
+    if (fieldsToExclude != null && !fieldsToExclude.isEmpty()) {
+      CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.addAll(fieldsToExclude);
+    }
+  }
+
+  public static void clearFieldsToExclude() {
+    CUSTOM_FIELDS_TO_EXCLUDE_IN_PREHASH.clear();
   }
 }

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -545,12 +545,12 @@ public class EventHashGeneratorPublisherTest {
         getClass()
             .getClassLoader()
             .getResourceAsStream(
-                "2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_with_errorDeclaration.json");
+                "2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_with_error_declaration.json");
     final InputStream epcisQueryDocument =
         getClass()
             .getClassLoader()
             .getResourceAsStream(
-                "2.0/EPCIS/JSON/Query/TransformationEvent_with_errorDeclaration.json");
+                "2.0/EPCIS/JSON/Query/TransformationEvent_with_error_declaration.json");
 
     final Multi<Map<String, String>> documentEventHash =
         eventHashGenerator.fromJson(epcisDocument, "prehash", "sha-256");

--- a/quarkus-app/src/main/resources/application.yml
+++ b/quarkus-app/src/main/resources/application.yml
@@ -2,7 +2,8 @@ quarkus:
   swagger-ui:
     always-include: true
   http:
-    cors: true
+    cors:
+      enabled: true
     port: 9000
 
   container-image:

--- a/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
+++ b/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
@@ -172,7 +172,7 @@ public class EventHashGeneratorResource {
 
     // If user has provided fields to ignore during hash generation then add them
     if (!StringUtils.isBlank(ignoreFields)) {
-      eventHashGenerator.customFieldsToIgnore(ignoreFields);
+      eventHashGenerator.excludeFieldsInPreHash(ignoreFields);
     }
 
     // Add the Hash Algorithm type to the List.

--- a/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
+++ b/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -146,7 +147,13 @@ public class EventHashGeneratorResource {
                       enumeration = {"true", "false"}))
           @DefaultValue("false")
           @QueryParam("beautifyPreHash")
-          Boolean beautifyPreHash)
+          Boolean beautifyPreHash,
+      @Parameter(
+              description = "Ignore fields for Hash-ID generation",
+              schema = @Schema(description = "empty defaults to no fields ignored"))
+          @DefaultValue("")
+          @QueryParam("ignoreFields")
+          String ignoreFields)
       throws IOException {
     // List to store the parameters based on the user provided inputs.
     final List<String> hashParameters = new ArrayList<>();
@@ -161,6 +168,11 @@ public class EventHashGeneratorResource {
       } else {
         eventHashGenerator.prehashJoin("");
       }
+    }
+
+    // If user has provided fields to ignore during hash generation then add them
+    if (!StringUtils.isBlank(ignoreFields)) {
+      eventHashGenerator.customFieldsToIgnore(ignoreFields);
     }
 
     // Add the Hash Algorithm type to the List.


### PR DESCRIPTION
@sboeckelmann 
Following the discussion between Bhavesh and Ralph, it was determined that the inclusion of an option to disregard repository-specific fields, such as `captureID`, `hash`, etc., was necessary. Due to the variable nature of these fields, we have implemented a feature that allows the user to specify the field names as a comma-separated value. Consequently, these designated fields will be excluded during the pre-hash string generation process.

Kindly request you to review the changes and approve the pull request.