### PR TITLE
OEPCIS-660: fixing issue with mismatch in event hash

### DIFF
--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -220,7 +220,10 @@ public class ContextNode {
     String fieldName = "";
 
     if (Boolean.TRUE.equals(isIlmdPath(node))) {
-      fieldName = userExtensionsFormatter(node.getName(), node.getValue(), namespaces);
+      if(!isArrayNode(node)){
+        fieldName = userExtensionsFormatter(node.getName(), node.getValue(), namespaces);
+      }
+     // fieldName = userExtensionsFormatter(node.getName(), node.getValue(), namespaces);
     } else if (node.getName() != null
         && TemplateNodeMap.isEpcisField(node)
         && DUPLICATE_ENTRY_CHECK.stream().noneMatch(node.getName()::equals)
@@ -468,6 +471,11 @@ public class ContextNode {
     } else {
       return name;
     }
+  }
+
+  //Check if the parent is array if not do not add the user extension namespace twice
+  private boolean isArrayNode(final ContextNode node){
+   return node.getName() != null && !node.getChildren().isEmpty() && node.getChildren().get(0).getName() != null && (node.getName().equals(node.getChildren().get(0).getName()) && node.getChildren().get(0).getValue() != null);
   }
 
   // Get the parent and their subsequent children (test purpose only)

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -649,25 +650,88 @@ public class EventHashGeneratorPublisherTest {
   }
 
   @Test
-  public void errorDeclarationXMLQueryDocumentTest() {
-    final InputStream epcisDocument =
-        getClass()
-            .getClassLoader()
-            .getResourceAsStream(
-                "2.0/EPCIS/XML/Capture/Documents/TransformationEvent_with_errorDeclaration.xml");
-    final InputStream epcisQueryDocument =
-        getClass()
-            .getClassLoader()
-            .getResourceAsStream(
-                "2.0/EPCIS/XML/Query/TransformationEvent_with_errorDeclaration.xml");
+  public void errorDeclarationXMLQueryDocumentTest() throws IOException {
+    final InputStream xmlDocument =
+            getClass()
+                    .getClassLoader()
+                    .getResourceAsStream(
+                            "2.0/EPCIS/XML/Capture/Documents/TransformationEvent_all_possible_fields.xml");
+    final InputStream jsonDocument =
+            getClass()
+                    .getClassLoader()
+                    .getResourceAsStream(
+                            "2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_all_possible_fields.json");
+
 
     final Multi<Map<String, String>> documentEventHash =
-        eventHashGenerator.fromXml(epcisDocument, "prehash", "sha-256");
+        eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256");
     final Multi<Map<String, String>> queryEventHash =
-        eventHashGenerator.fromXml(epcisQueryDocument, "prehash", "sha-256");
+        eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256");
 
     assertEquals(
         documentEventHash.subscribe().asStream().toList(),
         queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void xmlVsJsonCaptureDocument() throws IOException {
+    final InputStream xmlDocument =
+            getClass()
+                    .getClassLoader()
+                    .getResourceAsStream(
+                            "2.0/EPCIS/XML/Capture/Documents/TransformationEvent_with_userExtensions.xml");
+    final InputStream jsonDocument =
+            getClass()
+                    .getClassLoader()
+                    .getResourceAsStream(
+                            "2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_with_userExtensions.json");
+
+    final Multi<Map<String, String>> documentEventHash =
+            eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash =
+            eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256");
+
+    assertEquals(
+            documentEventHash.subscribe().asStream().toList(),
+            queryEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void objectEventAllFieldsTest() throws IOException {
+    final InputStream xmlDocument =
+            getClass()
+                    .getClassLoader()
+                    .getResourceAsStream(
+                            "2.0/EPCIS/XML/Capture/Documents/ObjectEvent_all_possible_fields.xml");
+    final InputStream jsonDocument =
+            getClass()
+                    .getClassLoader()
+                    .getResourceAsStream(
+                            "2.0/EPCIS/JSON/Capture/Documents/ObjectEvent_all_possible_fields.json");
+
+    final Multi<Map<String, String>> xmlEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> jsonEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256");
+
+    assertEquals(xmlEventHash.subscribe().asStream().toList(), jsonEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void transformationEventAllFieldsTest() throws IOException {
+    final InputStream xmlDocument =
+            getClass()
+                    .getClassLoader()
+                    .getResourceAsStream(
+                            "2.0/EPCIS/XML/Capture/Documents/TransformationEvent_all_possible_fields.xml");
+    final InputStream jsonDocument =
+            getClass()
+                    .getClassLoader()
+                    .getResourceAsStream(
+                            "2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_all_possible_fields.json");
+
+    eventHashGenerator.prehashJoin("\\n");
+    final Multi<Map<String, String>> xmlEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> jsonEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256");
+
+    assertEquals(xmlEventHash.subscribe().asStream().toList(), jsonEventHash.subscribe().asStream().toList());
   }
 }


### PR DESCRIPTION
@sboeckelmann 

This PR will fix the minor issue with a mismatch in event hash between XML and JSON documents. Additionally, there was some mismatch in the provided input document/event from [openepcis-test-resources](https://github.com/openepcis/openepcis-test-resources) which has been directly fixed in the project. 

Based on the fix seems like all document/event seems to be working correctly now. Kindly request you to review and approve the PR.