### PR TITLE
Bugfix/oepcis 694 fixing prehash string issues

### DIFF
--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -19,7 +19,6 @@ import static io.openepcis.epc.eventhash.constant.ConstantEventHashInfo.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import io.openepcis.constants.CBVVersion;
 import io.openepcis.constants.EPCIS;
 import io.openepcis.epc.eventhash.constant.ConstantEventHashInfo;
 import io.openepcis.epc.translator.util.ConverterUtil;
@@ -224,7 +223,7 @@ public class ContextNode {
         && node.getChildren() != null
         && !node.getChildren().isEmpty()
         && node.getChildren().get(0).getName() != null
-        && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_0_1.equals(EventHashGenerator.getCbvVersion()))
+        && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST))
         && (node.getName().equals(EPCIS.SENSOR_ELEMENT)
             || !node.getChildren().get(0).getName().equalsIgnoreCase(EPCIS.SENSOR_REPORT))) {
       // If the name does not contain null values & part of EPCIS standard fields then append to
@@ -296,7 +295,7 @@ public class ContextNode {
     } else {
 
       if (getName() != null
-          && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_0_1.equals(EventHashGenerator.getCbvVersion()))
+          && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST))
           && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
           && !ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(getName())
           && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)

--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -19,6 +19,7 @@ import static io.openepcis.epc.eventhash.constant.ConstantEventHashInfo.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.openepcis.constants.CBVVersion;
 import io.openepcis.constants.EPCIS;
 import io.openepcis.epc.eventhash.constant.ConstantEventHashInfo;
 import io.openepcis.epc.translator.util.ConverterUtil;
@@ -223,7 +224,7 @@ public class ContextNode {
         && node.getChildren() != null
         && !node.getChildren().isEmpty()
         && node.getChildren().get(0).getName() != null
-        && !node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST)
+        && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_0_1.equals(EventHashGenerator.getCbvVersion()))
         && (node.getName().equals(EPCIS.SENSOR_ELEMENT)
             || !node.getChildren().get(0).getName().equalsIgnoreCase(EPCIS.SENSOR_REPORT))) {
       // If the name does not contain null values & part of EPCIS standard fields then append to
@@ -295,7 +296,7 @@ public class ContextNode {
     } else {
 
       if (getName() != null
-          && !getName().equals(EPCIS.SENSOR_ELEMENT_LIST)
+          && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_0_1.equals(EventHashGenerator.getCbvVersion()))
           && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
           && !ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(getName())
           && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)

--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -42,9 +42,6 @@ public class EventHashGenerator {
   private static final SAXParserFactory SAX_PARSER_FACTORY = SAXParserFactory.newInstance();
   private String prehashJoin = "";
 
-  @Getter
-  private static CBVVersion cbvVersion;
-
   static {
     try {
       SAX_PARSER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
@@ -140,7 +137,6 @@ public class EventHashGenerator {
    */
   public Multi<Map<String, String>> fromJson(
     final InputStream jsonStream, final String... hashAlgorithms) throws IOException {
-    detectCBVVersion(hashAlgorithms); //Detect and store CBV version
     return fromJson(jsonStream, new HashMap<>(), hashAlgorithms);
   }
 
@@ -385,20 +381,6 @@ public class EventHashGenerator {
    */
   public Multi<Map<String, String>> fromXml(
       final InputStream xmlStream, final String... hashAlgorithms) {
-    detectCBVVersion(hashAlgorithms); //Detect and store CBV version
     return internalFromXml(Map.class, xmlStream, hashAlgorithms);
-  }
-
-  /**
-   * Detect the CBV version based on the provided input in hashAlgorithms
-   * If not specified then default the CBV version to CBV 2.0.1 (latest)
-   *
-   * @param hashAlgorithms contains the CBV Version i.e VERSION_2_0_0 or VERSION_2_0_1
-   */
-  private void detectCBVVersion(final String... hashAlgorithms){
-    //Get the corresponding cbv version if provided else default to CBV 2.1
-    cbvVersion = Arrays.stream(hashAlgorithms).map(CBVVersion::fromString)
-            .filter(Optional::isPresent).map(Optional::get)
-            .findFirst().orElse(CBVVersion.VERSION_2_0_1);
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
@@ -115,8 +115,6 @@ public class HashIdGenerator {
       }
     }
 
-    return hashId.append("?ver=")
-            .append(EventHashGenerator.getCbvVersion() == CBVVersion.VERSION_2_0_0 ? "CBV2.0" : "CBV2.1")
-            .toString();
+    return hashId.append("?ver=").append("CBV2.0").toString();
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
@@ -15,6 +15,7 @@
  */
 package io.openepcis.epc.eventhash;
 
+import io.openepcis.constants.CBVVersion;
 import jakarta.xml.bind.DatatypeConverter;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -114,6 +115,8 @@ public class HashIdGenerator {
       }
     }
 
-    return hashId.append("?ver=CBV2.0").toString();
+    return hashId.append("?ver=")
+            .append(EventHashGenerator.getCbvVersion() == CBVVersion.VERSION_2_0_0 ? "CBV2.0" : "CBV2.1")
+            .toString();
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/HashNodeComparator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/HashNodeComparator.java
@@ -166,7 +166,7 @@ public class HashNodeComparator implements Comparator<ContextNode> {
       }
     } else if (Boolean.FALSE.equals(standardFieldSort)) {
       // For extension append to extension string only the extension elements
-      if (child.getValue() != null) {
+      if (child.getValue() != null && child.getName() != null && child.getName().contains(":")) {
         // If value is present then append after user-extension formatting
         extensionString.append(
             contextNode.userExtensionsFormatter(

--- a/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
+++ b/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
@@ -149,17 +149,13 @@ public class EventHashGeneratorResource {
                   @Schema(
                       description = "empty defaults to sha-256",
                       enumeration = {
-                        "sha-1",
                         "sha-224",
                         "sha-256",
                         "sha-384",
                         "sha-512",
                         "sha3-224",
                         "sha3-256",
-                        "sha3-384",
-                        "sha3-512",
-                        "md2",
-                        "md5"
+                        "sha3-512"
                       }))
           @QueryParam("hashAlgorithm")
           String hashAlgorithm,


### PR DESCRIPTION
@sboeckelmann 

This PR will fix the issues associated with ordering the user extensions. Previously the complete node including the standard fields where considered during the ordering of the user extension fields which was not correct, so I have fixed it to include only the user extension elements during the sorting of extension fields. Also, removed some of the encryption to support only GS1-specified encryptions.

Kindly request you to review the changes and merge the PR.