### PR TITLE
OEPCIS-767: Add support for Event Hash Generation using CBV 2.1 version

### DIFF
--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -15,19 +15,21 @@
  */
 package io.openepcis.epc.eventhash;
 
-import static io.openepcis.epc.eventhash.constant.ConstantEventHashInfo.*;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.openepcis.constants.CBVVersion;
 import io.openepcis.constants.EPCIS;
 import io.openepcis.epc.eventhash.constant.ConstantEventHashInfo;
 import io.openepcis.epc.translator.util.ConverterUtil;
-import java.time.Instant;
-import java.util.*;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static io.openepcis.epc.eventhash.constant.ConstantEventHashInfo.*;
 
 /**
  * This class is utilized by EventHash and SaxHandler during the parsing of XML/JSON EPCIS document
@@ -155,9 +157,14 @@ public class ContextNode {
   // Method called by the external application after completion of converting the JSON/XML documents
   // into ContextNode.
   public String toShortenedString() {
-    // Add all the EPCIS standard fields to pre-hash string first then add all the users extensions
+    // For CBV 2.0: Add all the EPCIS standard fields to pre-hash string first then add all the users extensions
     // field that can appear anywhere with event and append the created string to pre-hash string.
-    return (epcisFieldsPreHashBuilder() + String.join("", userExtensionsPreHashBuilder())).trim();
+    if (CBVVersion.VERSION_2_0_0.equals(EventHashGenerator.getCbvVersion())) {
+      return (epcisFieldsPreHashBuilder() + String.join("", userExtensionsPreHashBuilder())).trim();
+    } else {
+      // For CBV 2.1: User Extensions that are part of standard fields are included within the respective field
+      return epcisFieldsPreHashBuilder().trim();
+    }
   }
 
   // Private method to return the Strings from well known EPCIS fields/attributes of EPCIS event
@@ -168,7 +175,7 @@ public class ContextNode {
     if (children.isEmpty()
         && getName() != null
         && getValue() != null
-        && TemplateNodeMap.isEpcisField(this)) {
+            && TemplateNodeMap.isEpcisField(this)) {
       // If the elements are EPCIS event root fields then directly append them to the pre-hash
       // string by formatting.
 
@@ -181,12 +188,13 @@ public class ContextNode {
       if (Boolean.TRUE.equals(isIlmdPath(this))) {
         preHashBuilder.append(userExtensionsFormatter(name, value, namespaces));
       } else {
-
         // Add the values for direct name and value based on the field
         preHashBuilder.append(epcisFieldFormatter(getName(), getValue(), this));
       }
 
       return preHashBuilder.toString();
+    } else if (children.isEmpty() && getName() != null && getValue() != null && !TemplateNodeMap.isEpcisField(this) && EventHashGenerator.getCbvVersion().equals(CBVVersion.VERSION_2_0_1)) {
+      return userExtensionsFormatter(this.getName(), this.getValue(), this.getNamespaces());
     } else {
       final StringBuilder sb = new StringBuilder();
 
@@ -198,7 +206,12 @@ public class ContextNode {
 
       // After sorting the child values loop through each of them and add values to pre-hash string
       for (ContextNode node : children) {
-        final String s = node.epcisFieldsPreHashBuilder();
+        String s = "";
+        if (node.getName() != null && !TemplateNodeMap.isEpcisField(node) && EventHashGenerator.getCbvVersion().equals(CBVVersion.VERSION_2_0_1)) {
+          s = node.userExtensionsPreHashBuilder();
+        } else {
+          s = node.epcisFieldsPreHashBuilder();
+        }
         if (!s.isEmpty()) {
           sb.append(s).append("\n");
         }
@@ -218,13 +231,13 @@ public class ContextNode {
         fieldName = userExtensionsFormatter(node.getName(), node.getValue(), namespaces);
       }
     } else if (node.getName() != null
-        && TemplateNodeMap.isEpcisField(node)
-        && DUPLICATE_ENTRY_CHECK.stream().noneMatch(node.getName()::equals)
-        && node.getChildren() != null
-        && !node.getChildren().isEmpty()
-        && node.getChildren().get(0).getName() != null
-        && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST))
-        && (node.getName().equals(EPCIS.SENSOR_ELEMENT)
+            && TemplateNodeMap.isEpcisField(node)
+            && DUPLICATE_ENTRY_CHECK.stream().noneMatch(node.getName()::equals)
+            && node.getChildren() != null
+            && !node.getChildren().isEmpty()
+            && node.getChildren().get(0).getName() != null
+            && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_0_1.equals(EventHashGenerator.getCbvVersion()))
+            && (node.getName().equals(EPCIS.SENSOR_ELEMENT)
             || !node.getChildren().get(0).getName().equalsIgnoreCase(EPCIS.SENSOR_REPORT))) {
       // If the name does not contain null values & part of EPCIS standard fields then append to
       // pre-hash string. Additional condition has been added to avoid the addition of sensorReport
@@ -295,15 +308,15 @@ public class ContextNode {
     } else {
 
       if (getName() != null
-          && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST))
-          && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
-          && !ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(getName())
-          && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)
-          && (getName().equals(EPCIS.SENSOR_ELEMENT)
+              && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_0_1.equals(EventHashGenerator.getCbvVersion()))
+              && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
+              && !ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(getName())
+              && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)
+              && (getName().equals(EPCIS.SENSOR_ELEMENT)
               || (!children.isEmpty()
-                  && children.get(0).getName() != null
-                  && !getName().equals(getChildren().get(0).getName())
-                  && !getChildren().get(0).getName().equalsIgnoreCase(EPCIS.SENSOR_REPORT)))) {
+              && children.get(0).getName() != null
+              && !getName().equals(getChildren().get(0).getName())
+              && !getChildren().get(0).getName().equalsIgnoreCase(EPCIS.SENSOR_REPORT)))) {
         sb.append(userExtensionsFormatter(getName(), getValue(), namespaces));
       }
 

--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -193,7 +193,7 @@ public class ContextNode {
       }
 
       return preHashBuilder.toString();
-    } else if (children.isEmpty() && getName() != null && getValue() != null && !TemplateNodeMap.isEpcisField(this) && EventHashGenerator.getCbvVersion().equals(CBVVersion.VERSION_2_0_1)) {
+    } else if (children.isEmpty() && getName() != null && getValue() != null && !TemplateNodeMap.isEpcisField(this) && EventHashGenerator.getCbvVersion().equals(CBVVersion.VERSION_2_1_0)) {
       return userExtensionsFormatter(this.getName(), this.getValue(), this.getNamespaces());
     } else {
       final StringBuilder sb = new StringBuilder();
@@ -207,7 +207,7 @@ public class ContextNode {
       // After sorting the child values loop through each of them and add values to pre-hash string
       for (ContextNode node : children) {
         String s = "";
-        if (node.getName() != null && !TemplateNodeMap.isEpcisField(node) && EventHashGenerator.getCbvVersion().equals(CBVVersion.VERSION_2_0_1)) {
+        if (node.getName() != null && !TemplateNodeMap.isEpcisField(node) && EventHashGenerator.getCbvVersion().equals(CBVVersion.VERSION_2_1_0)) {
           s = node.userExtensionsPreHashBuilder();
         } else {
           s = node.epcisFieldsPreHashBuilder();
@@ -236,7 +236,7 @@ public class ContextNode {
             && node.getChildren() != null
             && !node.getChildren().isEmpty()
             && node.getChildren().get(0).getName() != null
-            && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_0_1.equals(EventHashGenerator.getCbvVersion()))
+            && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_1_0.equals(EventHashGenerator.getCbvVersion()))
             && (node.getName().equals(EPCIS.SENSOR_ELEMENT)
             || !node.getChildren().get(0).getName().equalsIgnoreCase(EPCIS.SENSOR_REPORT))) {
       // If the name does not contain null values & part of EPCIS standard fields then append to
@@ -308,7 +308,7 @@ public class ContextNode {
     } else {
 
       if (getName() != null
-              && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_0_1.equals(EventHashGenerator.getCbvVersion()))
+              && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_1_0.equals(EventHashGenerator.getCbvVersion()))
               && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
               && !ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(getName())
               && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)

--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -393,7 +393,7 @@ public class EventHashGenerator {
 
   /**
    * Detect the CBV version based on the provided input in hashAlgorithms
-   * If not specified then default the CBV version to CBV 2.0.1 (latest)
+   * If not specified then default the CBV version to CBV 2.0.0 (latest)
    *
    * @param hashAlgorithms contains the CBV Version i.e VERSION_2_0_0 or VERSION_2_0_1
    */
@@ -403,6 +403,6 @@ public class EventHashGenerator {
             .map(CBVVersion::fromString)
             .flatMap(Optional::stream)
             .findFirst()
-            .orElse(CBVVersion.VERSION_2_0_1);
+            .orElse(CBVVersion.VERSION_2_0_0);
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -395,7 +395,7 @@ public class EventHashGenerator {
    * Detect the CBV version based on the provided input in hashAlgorithms
    * If not specified then default the CBV version to CBV 2.0.0 (latest)
    *
-   * @param hashAlgorithms contains the CBV Version i.e VERSION_2_0_0 or VERSION_2_0_1
+   * @param hashAlgorithms contains the CBV Version i.e VERSION_2_0_0 or VERSION_2_1_0
    */
   private void detectCBVVersion(final String... hashAlgorithms){
     //Get the corresponding cbv version if provided else default to CBV 2.1

--- a/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
@@ -115,6 +115,8 @@ public class HashIdGenerator {
       }
     }
 
-    return hashId.append("?ver=").append("CBV2.0").toString();
+    return hashId.append("?ver=")
+            .append(EventHashGenerator.getCbvVersion() == CBVVersion.VERSION_2_0_0 ? "CBV2.0" : "CBV2.1")
+            .toString();
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/HashNodeComparator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/HashNodeComparator.java
@@ -63,7 +63,14 @@ public class HashNodeComparator implements Comparator<ContextNode> {
           return sortUserExtensions(o1, o2);
         } else if (o1.getChildren() != null && o2.getChildren() != null) {
           // If children is present then sort based on children elements
-          return findChildren(o1).compareTo(findChildren(o2));
+          boolean o1IsEpcisField = TemplateNodeMap.isEpcisField(o1);
+          boolean o2IsEpcisField = TemplateNodeMap.isEpcisField(o2);
+
+          if (o1IsEpcisField != o2IsEpcisField) {
+            return o1IsEpcisField ? -1 : 1;
+          } else {
+            return findChildren(o1).compareTo(findChildren(o2));
+          }
         } else {
           // For dedicated epcis fields sort based on the name
           return o1.getName().compareTo(o2.getName());

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -18,6 +18,7 @@ package io.openepcis.epc.eventhash;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import io.openepcis.constants.CBVVersion;
 import io.smallrye.mutiny.Multi;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -733,5 +734,29 @@ public class EventHashGeneratorPublisherTest {
     final Multi<Map<String, String>> jsonEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256");
 
     assertEquals(xmlEventHash.subscribe().asStream().toList(), jsonEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void transformationEventAllFieldsTestVersion2_1() throws IOException {
+    final InputStream xmlDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/XML/Capture/Documents/TransformationEvent_all_possible_fields.xml");
+    final InputStream jsonDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_all_possible_fields.json");
+
+    eventHashGenerator.prehashJoin("\\n");
+    final Multi<Map<String, String>> xmlEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256", CBVVersion.VERSION_2_0_1.getVersion());
+    final Multi<Map<String, String>> jsonEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256", CBVVersion.VERSION_2_0_1.getVersion());
+
+    assertEquals(xmlEventHash.subscribe().asStream().toList(), jsonEventHash.subscribe().asStream().toList());
+  }
+
+  @Test
+  public void xmlVsJsonCaptureDocumentVersion2_1() throws IOException {
+    final InputStream xmlDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/XML/Capture/Documents/TransformationEvent_with_userExtensions.xml");
+    final InputStream jsonDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_with_userExtensions.json");
+
+    eventHashGenerator.prehashJoin("\\n");
+    final Multi<Map<String, String>> documentEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256", CBVVersion.VERSION_2_0_1.getVersion());
+    final Multi<Map<String, String>> queryEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256", CBVVersion.VERSION_2_0_1.getVersion());
+
+    assertEquals(documentEventHash.subscribe().asStream().toList(), queryEventHash.subscribe().asStream().toList());
   }
 }

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -742,8 +742,8 @@ public class EventHashGeneratorPublisherTest {
     final InputStream jsonDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_all_possible_fields.json");
 
     eventHashGenerator.prehashJoin("\\n");
-    final Multi<Map<String, String>> xmlEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256", CBVVersion.VERSION_2_0_1.getVersion());
-    final Multi<Map<String, String>> jsonEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256", CBVVersion.VERSION_2_0_1.getVersion());
+    final Multi<Map<String, String>> xmlEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256", CBVVersion.VERSION_2_1_0.getVersion());
+    final Multi<Map<String, String>> jsonEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256", CBVVersion.VERSION_2_1_0.getVersion());
 
     assertEquals(xmlEventHash.subscribe().asStream().toList(), jsonEventHash.subscribe().asStream().toList());
   }
@@ -754,8 +754,8 @@ public class EventHashGeneratorPublisherTest {
     final InputStream jsonDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_with_userExtensions.json");
 
     eventHashGenerator.prehashJoin("\\n");
-    final Multi<Map<String, String>> documentEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256", CBVVersion.VERSION_2_0_1.getVersion());
-    final Multi<Map<String, String>> queryEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256", CBVVersion.VERSION_2_0_1.getVersion());
+    final Multi<Map<String, String>> documentEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256", CBVVersion.VERSION_2_1_0.getVersion());
+    final Multi<Map<String, String>> queryEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256", CBVVersion.VERSION_2_1_0.getVersion());
 
     assertEquals(documentEventHash.subscribe().asStream().toList(), queryEventHash.subscribe().asStream().toList());
   }


### PR DESCRIPTION
@sboeckelmann 
This pull request will add support to the CBV 2.1 version where the following changes are currently supported, please let me know if I have missed something:

1. User extensions are appended immediately after the respective fields instead of at the end together.

2. `SensorElementList` keyword is added before the respective Sensor elements.

3. Event hash will have `CBV2.1` at the end of the Hash ID instead of the regular `CBV2.0`.

In our code currently, we will be defaulting to `CBV2.0` if the user has not specified the CBV version else user-defined version will be used. Please review the changes and approve the PR.