### PR TITLE
Oepcis 767 support cbv version 2.1

### DIFF
--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -156,20 +156,20 @@ public class ContextNode {
 
   // Method called by the external application after completion of converting the JSON/XML documents
   // into ContextNode.
-  public String toShortenedString() {
+  public String toShortenedString(final CBVVersion cbvVersion) {
     // For CBV 2.0: Add all the EPCIS standard fields to pre-hash string first then add all the users extensions
     // field that can appear anywhere with event and append the created string to pre-hash string.
-    if (CBVVersion.VERSION_2_0_0.equals(EventHashGenerator.getCbvVersion())) {
-      return (epcisFieldsPreHashBuilder() + String.join("", userExtensionsPreHashBuilder())).trim();
+    if (CBVVersion.VERSION_2_0_0.equals(cbvVersion)) {
+      return (epcisFieldsPreHashBuilder(cbvVersion) + String.join("", userExtensionsPreHashBuilder(cbvVersion))).trim();
     } else {
       // For CBV 2.1: User Extensions that are part of standard fields are included within the respective field
-      return epcisFieldsPreHashBuilder().trim();
+      return epcisFieldsPreHashBuilder(cbvVersion).trim();
     }
   }
 
   // Private method to return the Strings from well known EPCIS fields/attributes of EPCIS event
   // such as type, eventTime, bizStep etc. by omitting the User-Extensions.
-  private String epcisFieldsPreHashBuilder() {
+  private String epcisFieldsPreHashBuilder(final CBVVersion cbvVersion) {
     // Check if the elements are of root elements and do not contain the children elements. If the
     // element is part of EPCIS standard fields then append to pre-hash string.
     if (children.isEmpty()
@@ -193,13 +193,13 @@ public class ContextNode {
       }
 
       return preHashBuilder.toString();
-    } else if (children.isEmpty() && getName() != null && getValue() != null && !TemplateNodeMap.isEpcisField(this) && EventHashGenerator.getCbvVersion().equals(CBVVersion.VERSION_2_1_0)) {
+    } else if (children.isEmpty() && getName() != null && getValue() != null && !TemplateNodeMap.isEpcisField(this) && cbvVersion.equals(CBVVersion.VERSION_2_1_0)) {
       return userExtensionsFormatter(this.getName(), this.getValue(), this.getNamespaces());
     } else {
       final StringBuilder sb = new StringBuilder();
 
       // Call the function to add the EPCIS field name for children elements
-      sb.append(fieldName(this));
+      sb.append(fieldName(this, cbvVersion));
 
       // If child values are present then sort them according to event hash requirement
       this.sort(true);
@@ -207,10 +207,10 @@ public class ContextNode {
       // After sorting the child values loop through each of them and add values to pre-hash string
       for (ContextNode node : children) {
         String s = "";
-        if (node.getName() != null && !TemplateNodeMap.isEpcisField(node) && EventHashGenerator.getCbvVersion().equals(CBVVersion.VERSION_2_1_0)) {
-          s = node.userExtensionsPreHashBuilder();
+        if (node.getName() != null && !TemplateNodeMap.isEpcisField(node) && cbvVersion.equals(CBVVersion.VERSION_2_1_0)) {
+          s = node.userExtensionsPreHashBuilder(cbvVersion);
         } else {
-          s = node.epcisFieldsPreHashBuilder();
+          s = node.epcisFieldsPreHashBuilder(cbvVersion);
         }
         if (!s.isEmpty()) {
           sb.append(s).append("\n");
@@ -221,7 +221,7 @@ public class ContextNode {
   }
 
   // Private method to append the EPCIS field name during the child elements formatting.
-  private String fieldName(final ContextNode node) {
+  private String fieldName(final ContextNode node, final CBVVersion cbvVersion) {
     // For ILMD fields make call to userExtensions formatter and for all other fields make call to
     // normal field formatter.
     String fieldName = "";
@@ -236,7 +236,7 @@ public class ContextNode {
             && node.getChildren() != null
             && !node.getChildren().isEmpty()
             && node.getChildren().get(0).getName() != null
-            && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_1_0.equals(EventHashGenerator.getCbvVersion()))
+            && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || cbvVersion.equals(CBVVersion.VERSION_2_1_0))
             && (node.getName().equals(EPCIS.SENSOR_ELEMENT)
             || !node.getChildren().get(0).getName().equalsIgnoreCase(EPCIS.SENSOR_REPORT))) {
       // If the name does not contain null values & part of EPCIS standard fields then append to
@@ -290,7 +290,7 @@ public class ContextNode {
 
   // Private method to return the List of Strings contains the  user-defined extensions in required
   // pre-hash format.
-  private String userExtensionsPreHashBuilder() {
+  private String userExtensionsPreHashBuilder(final CBVVersion cbvVersion) {
     // Create a string and append the values when the provided value is empty i.e. for complex
     // structures.
     StringBuilder sb = new StringBuilder();
@@ -308,7 +308,7 @@ public class ContextNode {
     } else {
 
       if (getName() != null
-              && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_1_0.equals(EventHashGenerator.getCbvVersion()))
+              && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || cbvVersion.equals(CBVVersion.VERSION_2_1_0))
               && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
               && !ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(getName())
               && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)
@@ -324,7 +324,7 @@ public class ContextNode {
       this.sort(false);
 
       for (ContextNode node : children) {
-        final String childExtension = node.userExtensionsPreHashBuilder();
+        final String childExtension = node.userExtensionsPreHashBuilder(cbvVersion);
         if (!childExtension.isEmpty()) {
           sb.append(childExtension).append("\n");
         }

--- a/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/ContextNode.java
@@ -193,7 +193,7 @@ public class ContextNode {
       }
 
       return preHashBuilder.toString();
-    } else if (children.isEmpty() && getName() != null && getValue() != null && !TemplateNodeMap.isEpcisField(this) && cbvVersion.equals(CBVVersion.VERSION_2_1_0)) {
+    } else if (children.isEmpty() && getName() != null && getValue() != null && !TemplateNodeMap.isEpcisField(this) && CBVVersion.VERSION_2_1_0.equals(cbvVersion)) {
       return userExtensionsFormatter(this.getName(), this.getValue(), this.getNamespaces());
     } else {
       final StringBuilder sb = new StringBuilder();
@@ -207,7 +207,7 @@ public class ContextNode {
       // After sorting the child values loop through each of them and add values to pre-hash string
       for (ContextNode node : children) {
         String s = "";
-        if (node.getName() != null && !TemplateNodeMap.isEpcisField(node) && cbvVersion.equals(CBVVersion.VERSION_2_1_0)) {
+        if (node.getName() != null && !TemplateNodeMap.isEpcisField(node) && CBVVersion.VERSION_2_1_0.equals(cbvVersion)) {
           s = node.userExtensionsPreHashBuilder(cbvVersion);
         } else {
           s = node.epcisFieldsPreHashBuilder(cbvVersion);
@@ -236,7 +236,7 @@ public class ContextNode {
             && node.getChildren() != null
             && !node.getChildren().isEmpty()
             && node.getChildren().get(0).getName() != null
-            && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || cbvVersion.equals(CBVVersion.VERSION_2_1_0))
+            && (!node.getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_1_0.equals(cbvVersion))
             && (node.getName().equals(EPCIS.SENSOR_ELEMENT)
             || !node.getChildren().get(0).getName().equalsIgnoreCase(EPCIS.SENSOR_REPORT))) {
       // If the name does not contain null values & part of EPCIS standard fields then append to
@@ -308,7 +308,7 @@ public class ContextNode {
     } else {
 
       if (getName() != null
-              && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || cbvVersion.equals(CBVVersion.VERSION_2_1_0))
+              && (!getName().equals(EPCIS.SENSOR_ELEMENT_LIST) || CBVVersion.VERSION_2_1_0.equals(cbvVersion))
               && (!TemplateNodeMap.isEpcisField(this) || TemplateNodeMap.addExtensionWrapperTag(this))
               && !ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(getName())
               && !findParent(this).equalsIgnoreCase(EPCIS.CONTEXT)

--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -32,18 +32,14 @@ import java.util.function.Consumer;
 import javax.xml.parsers.SAXParserFactory;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
-@NoArgsConstructor
 public class EventHashGenerator {
   private static final SAXParserFactory SAX_PARSER_FACTORY = SAXParserFactory.newInstance();
   private String prehashJoin = "";
-
-  @Getter
-  private static CBVVersion cbvVersion;
+  private final CBVVersion cbvVersion;
 
   static {
     try {
@@ -51,6 +47,25 @@ public class EventHashGenerator {
     } catch (Exception e) {
       log.error(e.getMessage(), e);
     }
+  }
+
+  /**
+   *  Default constructor which generates the pre-hash string based on CBV 2.0
+   */
+  public EventHashGenerator(){
+    this.cbvVersion = CBVVersion.VERSION_2_0_0;
+  }
+
+  /**
+   *  Constructor which generates the pre-hash string based on provided CBV version
+   * @param cbvVersion required CBV version that needs to be used for pre-hash string generation.
+   */
+  public EventHashGenerator(final CBVVersion cbvVersion){
+    this.cbvVersion = cbvVersion;
+  }
+
+  public final EventHashGenerator mapCbvVersion(final CBVVersion cbvVersion) {
+    return new EventHashGenerator(cbvVersion);
   }
 
   public void prehashJoin(final String s) {
@@ -260,13 +275,11 @@ public class EventHashGenerator {
       final ObjectNode objectNode,
       final Map<String, String> contextHeader,
       final String... hashAlgorithms) {
-    detectCBVVersion(hashAlgorithms); //Detect and store CBV version
-
     addToContextHeader(objectNode, contextHeader);
     if (!objectNode.get(EPCIS.TYPE).asText().equalsIgnoreCase(EPCIS.EPCIS_DOCUMENT)
         && !objectNode.get(EPCIS.TYPE).asText().equalsIgnoreCase(EPCIS.EPCIS_QUERY_DOCUMENT)) {
       final ContextNode contextNode = new ContextNode(objectNode.fields(), contextHeader);
-      final String preHashString = contextNode.toShortenedString();
+      final String preHashString = contextNode.toShortenedString(this.cbvVersion);
 
       // Call the method generateHashId in HashIdGenerator to
       return generate(cls, preHashString, hashAlgorithms);
@@ -315,7 +328,7 @@ public class EventHashGenerator {
         if (hashAlgorithms.length != 1) {
           throw new EventHashException("only one single algorithm allowed for type String");
         }
-        return (T) HashIdGenerator.generateHashId(s.replaceAll("[\n\r]", ""), hashAlgorithms[0]);
+        return (T) HashIdGenerator.generateHashId(s.replaceAll("[\n\r]", ""), hashAlgorithms[0], this.cbvVersion);
       }
       final Map<String, String> map = new HashMap<>();
       for (final String hashAlgorithm : hashAlgorithms) {
@@ -324,7 +337,7 @@ public class EventHashGenerator {
         } else {
           map.put(
               hashAlgorithm,
-              HashIdGenerator.generateHashId(s.replaceAll("[\n\r]", ""), hashAlgorithm));
+              HashIdGenerator.generateHashId(s.replaceAll("[\n\r]", ""), hashAlgorithm, this.cbvVersion));
         }
       }
       return (T) map;
@@ -346,15 +359,12 @@ public class EventHashGenerator {
             contextNodeMultiEmitter.fail(e);
           }
         };
-
-    detectCBVVersion(hashAlgorithms); //Detect and store CBV version
-
     // After converting each XML event to ContextNode and storing information in rootNode, convert
     // it to pre-hash string and generate HashId out of it.
     return (Multi<T>)
         Multi.createFrom()
             .emitter(consumer)
-            .map(node -> generate(cls, node.toShortenedString(), hashAlgorithms))
+            .map(node -> generate(cls, node.toShortenedString(this.cbvVersion), hashAlgorithms))
             .filter(
                 m -> {
                   if (cls.isAssignableFrom(String.class)) {
@@ -389,20 +399,5 @@ public class EventHashGenerator {
   public Multi<Map<String, String>> fromXml(
       final InputStream xmlStream, final String... hashAlgorithms) {
     return internalFromXml(Map.class, xmlStream, hashAlgorithms);
-  }
-
-  /**
-   * Detect the CBV version based on the provided input in hashAlgorithms
-   * If not specified then default the CBV version to CBV 2.0.0 (latest)
-   *
-   * @param hashAlgorithms contains the CBV Version i.e VERSION_2_0_0 or VERSION_2_1_0
-   */
-  private void detectCBVVersion(final String... hashAlgorithms){
-    //Get the corresponding cbv version if provided else default to CBV 2.1
-    cbvVersion = Arrays.stream(hashAlgorithms)
-            .map(CBVVersion::fromString)
-            .flatMap(Optional::stream)
-            .findFirst()
-            .orElse(CBVVersion.VERSION_2_0_0);
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -64,6 +64,11 @@ public class EventHashGenerator {
     this.cbvVersion = cbvVersion;
   }
 
+  /**
+   * Method to generate the instance of the EventHashGenerator based on provided CBV Version
+   * @param cbvVersion required CBV version that needs to be used for pre-hash string generation.
+   * @return EventHashGenerator with required CBV version
+   */
   public final EventHashGenerator mapCbvVersion(final CBVVersion cbvVersion) {
     return new EventHashGenerator(cbvVersion);
   }

--- a/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/EventHashGenerator.java
@@ -61,7 +61,7 @@ public class EventHashGenerator {
    * @param cbvVersion required CBV version that needs to be used for pre-hash string generation.
    */
   public EventHashGenerator(final CBVVersion cbvVersion){
-    this.cbvVersion = cbvVersion;
+    this.cbvVersion = cbvVersion != null ? cbvVersion : CBVVersion.VERSION_2_0_0;
   }
 
   /**

--- a/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 public class HashIdGenerator {
 
   // Method which accepts the pre-hash string for which SHA-256 hash-id needs to be created.
-  public static String generateHashId(final String preHashString, final String hashAlgorithm)
+  public static String generateHashId(final String preHashString, final String hashAlgorithm, final CBVVersion cbvVersion)
       throws NoSuchAlgorithmException {
     // Create the StringBuilder to append prefix, hash and suffix according to required EPCIS
     // standard.
@@ -116,7 +116,7 @@ public class HashIdGenerator {
     }
 
     return hashId.append("?ver=")
-            .append(EventHashGenerator.getCbvVersion() == CBVVersion.VERSION_2_0_0 ? "CBV2.0" : "CBV2.1")
+            .append(cbvVersion.equals(CBVVersion.VERSION_2_0_0) ? "CBV2.0" : "CBV2.1")
             .toString();
   }
 }

--- a/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
+++ b/core/src/main/java/io/openepcis/epc/eventhash/HashIdGenerator.java
@@ -116,7 +116,7 @@ public class HashIdGenerator {
     }
 
     return hashId.append("?ver=")
-            .append(cbvVersion.equals(CBVVersion.VERSION_2_0_0) ? "CBV2.0" : "CBV2.1")
+            .append(CBVVersion.VERSION_2_0_0.equals(cbvVersion) ? "CBV2.0" : "CBV2.1")
             .toString();
   }
 }

--- a/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/epc/eventhash/EventHashGeneratorPublisherTest.java
@@ -15,11 +15,11 @@
  */
 package io.openepcis.epc.eventhash;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-
 import io.openepcis.constants.CBVVersion;
 import io.smallrye.mutiny.Multi;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,16 +27,20 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class EventHashGeneratorPublisherTest {
 
   private EventHashGenerator eventHashGenerator;
+  private EventHashGenerator eventHashGenerator2_1;
 
   @Before
   public void before() {
     eventHashGenerator = new EventHashGenerator();
+    eventHashGenerator2_1 = new EventHashGenerator(CBVVersion.VERSION_2_1_0);
+    eventHashGenerator.prehashJoin("\\n");
+    eventHashGenerator2_1.prehashJoin("\\n");
   }
 
   // General test to fix bugs or necessary code modification for XML document.
@@ -729,7 +733,6 @@ public class EventHashGeneratorPublisherTest {
                     .getResourceAsStream(
                             "2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_all_possible_fields.json");
 
-    eventHashGenerator.prehashJoin("\\n");
     final Multi<Map<String, String>> xmlEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256");
     final Multi<Map<String, String>> jsonEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256");
 
@@ -741,9 +744,8 @@ public class EventHashGeneratorPublisherTest {
     final InputStream xmlDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/XML/Capture/Documents/TransformationEvent_all_possible_fields.xml");
     final InputStream jsonDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_all_possible_fields.json");
 
-    eventHashGenerator.prehashJoin("\\n");
-    final Multi<Map<String, String>> xmlEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256", CBVVersion.VERSION_2_1_0.getVersion());
-    final Multi<Map<String, String>> jsonEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256", CBVVersion.VERSION_2_1_0.getVersion());
+    final Multi<Map<String, String>> xmlEventHash = eventHashGenerator2_1.fromXml(xmlDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> jsonEventHash = eventHashGenerator2_1.fromJson(jsonDocument, "prehash", "sha-256");
 
     assertEquals(xmlEventHash.subscribe().asStream().toList(), jsonEventHash.subscribe().asStream().toList());
   }
@@ -753,9 +755,8 @@ public class EventHashGeneratorPublisherTest {
     final InputStream xmlDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/XML/Capture/Documents/TransformationEvent_with_userExtensions.xml");
     final InputStream jsonDocument = getClass().getClassLoader().getResourceAsStream("2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_with_userExtensions.json");
 
-    eventHashGenerator.prehashJoin("\\n");
-    final Multi<Map<String, String>> documentEventHash = eventHashGenerator.fromXml(xmlDocument, "prehash", "sha-256", CBVVersion.VERSION_2_1_0.getVersion());
-    final Multi<Map<String, String>> queryEventHash = eventHashGenerator.fromJson(jsonDocument, "prehash", "sha-256", CBVVersion.VERSION_2_1_0.getVersion());
+    final Multi<Map<String, String>> documentEventHash = eventHashGenerator2_1.fromXml(xmlDocument, "prehash", "sha-256");
+    final Multi<Map<String, String>> queryEventHash = eventHashGenerator2_1.fromJson(jsonDocument, "prehash", "sha-256");
 
     assertEquals(documentEventHash.subscribe().asStream().toList(), queryEventHash.subscribe().asStream().toList());
   }

--- a/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
+++ b/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
@@ -219,7 +219,7 @@ public class EventHashGeneratorResource {
     hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
     // Based on CBV version provided set the respective cbv version, default to 2.0.0
-    final CBVVersion targetCbvVersion = CBVVersion.VERSION_2_1_0.equals(CBVVersion.toCbvVersion(cbvVersion)) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+    final CBVVersion targetCbvVersion = CBVVersion.VERSION_2_1_0.equals(CBVVersion.of(cbvVersion)) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
 
     return (contentType.contains("application/xml")
             ? eventHashGenerator.mapCbvVersion(targetCbvVersion).fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))
@@ -374,7 +374,7 @@ public class EventHashGeneratorResource {
     hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
     // Based on CBV version provided set the respective cbv version, default to 2.0.0
-    final CBVVersion targetCbvVersion = CBVVersion.VERSION_2_1_0.equals(CBVVersion.toCbvVersion(cbvVersion)) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+    final CBVVersion targetCbvVersion = CBVVersion.VERSION_2_1_0.equals(CBVVersion.of(cbvVersion)) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
 
     return (contentType.contains("application/xml")
             ? eventHashGenerator.mapCbvVersion(targetCbvVersion).fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))

--- a/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
+++ b/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
@@ -316,17 +316,13 @@ public class EventHashGeneratorResource {
                   @Schema(
                       description = "empty defaults to sha-256",
                       enumeration = {
-                        "sha-1",
                         "sha-224",
                         "sha-256",
                         "sha-384",
                         "sha-512",
                         "sha3-224",
                         "sha3-256",
-                        "sha3-384",
-                        "sha3-512",
-                        "md2",
-                        "md5"
+                        "sha3-512"
                       }))
           @DefaultValue("sha-256")
           @QueryParam("hashAlgorithm")

--- a/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
+++ b/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
@@ -16,6 +16,7 @@
 package openepcis.epc.eventhash.generator.resource;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import io.openepcis.constants.CBVVersion;
 import io.openepcis.epc.eventhash.DocumentWrapperSupport;
 import io.openepcis.epc.eventhash.EventHashGenerator;
 import io.openepcis.model.epcis.EPCISDocument;
@@ -157,6 +158,7 @@ public class EventHashGeneratorResource {
                         "sha3-256",
                         "sha3-512"
                       }))
+          @DefaultValue("sha-256")
           @QueryParam("hashAlgorithm")
           String hashAlgorithm,
       @Parameter(
@@ -182,7 +184,16 @@ public class EventHashGeneratorResource {
               schema = @Schema(description = "empty defaults to no fields ignored"))
           @DefaultValue("")
           @QueryParam("ignoreFields")
-          String ignoreFields)
+          String ignoreFields,
+      @Parameter(
+              description = "CBV version based on which Pre-Hash String and Hash-Id needs to be generated",
+              schema =
+              @Schema(
+                      description = "empty defaults to CBV version 2.0.0",
+                      enumeration = {"2.0.0", "2.1.0"}))
+      @DefaultValue("2.0.0")
+      @QueryParam("cbvVersion")
+      String cbvVersion)
       throws IOException {
     // List to store the parameters based on the user provided inputs.
     final List<String> hashParameters = new ArrayList<>();
@@ -207,9 +218,12 @@ public class EventHashGeneratorResource {
     // Add the Hash Algorithm type to the List.
     hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
+    // Based on CBV version provided set the respective cbv version, default to 2.0.0
+    final CBVVersion targetCbvVersion = "2.1.0".equals(cbvVersion) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+
     return (contentType.contains("application/xml")
-            ? eventHashGenerator.fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))
-            : eventHashGenerator.fromJson(
+            ? eventHashGenerator.mapCbvVersion(targetCbvVersion).fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))
+            : eventHashGenerator.mapCbvVersion(targetCbvVersion).fromJson(
                 inputDocumentStream, hashParameters.toArray(String[]::new)))
         .runSubscriptionOn(managedExecutor);
   }
@@ -314,6 +328,7 @@ public class EventHashGeneratorResource {
                         "md2",
                         "md5"
                       }))
+          @DefaultValue("sha-256")
           @QueryParam("hashAlgorithm")
           String hashAlgorithm,
       @Parameter(
@@ -333,7 +348,16 @@ public class EventHashGeneratorResource {
                       enumeration = {"true", "false"}))
           @DefaultValue("false")
           @QueryParam("beautifyPreHash")
-          Boolean beautifyPreHash)
+          Boolean beautifyPreHash,
+      @Parameter(
+              description = "CBV version based on which Pre-Hash String and Hash-Id needs to be generated",
+              schema =
+              @Schema(
+                      description = "empty defaults to CBV version 2.0.0",
+                      enumeration = {"2.0.0", "2.1.0"}))
+      @DefaultValue("2.0.0")
+      @QueryParam("cbvVersion")
+      String cbvVersion)
       throws IOException {
     // List to store the parameters based on the user provided inputs.
     final List<String> hashParameters = new ArrayList<>();
@@ -353,9 +377,12 @@ public class EventHashGeneratorResource {
     // Add the Hash Algorithm type to the List.
     hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
+    // Based on CBV version provided set the respective cbv version, default to 2.0.0
+    final CBVVersion targetCbvVersion = "2.1.0".equals(cbvVersion) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+
     return (contentType.contains("application/xml")
-            ? eventHashGenerator.fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))
-            : eventHashGenerator.fromJson(
+            ? eventHashGenerator.mapCbvVersion(targetCbvVersion).fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))
+            : eventHashGenerator.mapCbvVersion(targetCbvVersion).fromJson(
                 documentWrapperSupport.generateJsonDocumentWrapper(inputDocumentStream),
                 hashParameters.toArray(String[]::new)))
         .runSubscriptionOn(managedExecutor);

--- a/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
+++ b/rest-api/src/main/java/openepcis/epc/eventhash/generator/resource/EventHashGeneratorResource.java
@@ -219,7 +219,7 @@ public class EventHashGeneratorResource {
     hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
     // Based on CBV version provided set the respective cbv version, default to 2.0.0
-    final CBVVersion targetCbvVersion = "2.1.0".equals(cbvVersion) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+    final CBVVersion targetCbvVersion = CBVVersion.VERSION_2_1_0.equals(CBVVersion.toCbvVersion(cbvVersion)) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
 
     return (contentType.contains("application/xml")
             ? eventHashGenerator.mapCbvVersion(targetCbvVersion).fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))
@@ -374,7 +374,7 @@ public class EventHashGeneratorResource {
     hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
     // Based on CBV version provided set the respective cbv version, default to 2.0.0
-    final CBVVersion targetCbvVersion = "2.1.0".equals(cbvVersion) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+    final CBVVersion targetCbvVersion = CBVVersion.VERSION_2_1_0.equals(CBVVersion.toCbvVersion(cbvVersion)) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
 
     return (contentType.contains("application/xml")
             ? eventHashGenerator.mapCbvVersion(targetCbvVersion).fromXml(inputDocumentStream, hashParameters.toArray(String[]::new))

--- a/servlet-api/src/main/java/openepcis/epc/eventhash/generator/servlet/EventHashGeneratorServlets.java
+++ b/servlet-api/src/main/java/openepcis/epc/eventhash/generator/servlet/EventHashGeneratorServlets.java
@@ -74,7 +74,7 @@ public class EventHashGeneratorServlets {
 
                 // Add provided CBV version else default to CBV 2.0.0
                 final String cbvVersion = Optional.ofNullable(req.getParameter("cbvVersion")).orElse(CBVVersion.VERSION_2_0_0.getVersion());
-                final CBVVersion targetCbvVersion = CBVVersion.toCbvVersion(cbvVersion);
+                final CBVVersion targetCbvVersion = CBVVersion.of(cbvVersion);
 
                 Optional<String> accept = servletSupport.accept(List.of(MediaType.APPLICATION_JSON, MediaType.WILDCARD), req, resp);
                 if (accept.isEmpty()) {
@@ -138,7 +138,7 @@ public class EventHashGeneratorServlets {
 
                 // Add provided CBV version else default to CBV 2.0.0
                 final String cbvVersion = Optional.ofNullable(req.getParameter("cbvVersion")).orElse(CBVVersion.VERSION_2_0_0.getVersion());
-                final CBVVersion targetCbvVersion = CBVVersion.toCbvVersion(cbvVersion);
+                final CBVVersion targetCbvVersion = CBVVersion.of(cbvVersion);
 
                 Optional<String> accept = servletSupport.accept(List.of(MediaType.APPLICATION_JSON, MediaType.WILDCARD), req, resp);
                 if (accept.isEmpty()) {

--- a/servlet-api/src/main/java/openepcis/epc/eventhash/generator/servlet/EventHashGeneratorServlets.java
+++ b/servlet-api/src/main/java/openepcis/epc/eventhash/generator/servlet/EventHashGeneratorServlets.java
@@ -73,8 +73,8 @@ public class EventHashGeneratorServlets {
                 hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
                 // Add provided CBV version else default to CBV 2.0.0
-                final String cbvVersion = Optional.ofNullable(req.getParameter("cbvVersion")).orElse("2.0.0");
-                final CBVVersion targetCbvVersion = "2.1.0".equals(cbvVersion) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+                final String cbvVersion = Optional.ofNullable(req.getParameter("cbvVersion")).orElse(CBVVersion.VERSION_2_0_0.getVersion());
+                final CBVVersion targetCbvVersion = CBVVersion.toCbvVersion(cbvVersion);
 
                 Optional<String> accept = servletSupport.accept(List.of(MediaType.APPLICATION_JSON, MediaType.WILDCARD), req, resp);
                 if (accept.isEmpty()) {
@@ -137,8 +137,8 @@ public class EventHashGeneratorServlets {
                 hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
 
                 // Add provided CBV version else default to CBV 2.0.0
-                final String cbvVersion = Optional.ofNullable(req.getParameter("cbvVersion")).orElse("2.0.0");
-                final CBVVersion targetCbvVersion = "2.1.0".equals(cbvVersion) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+                final String cbvVersion = Optional.ofNullable(req.getParameter("cbvVersion")).orElse(CBVVersion.VERSION_2_0_0.getVersion());
+                final CBVVersion targetCbvVersion = CBVVersion.toCbvVersion(cbvVersion);
 
                 Optional<String> accept = servletSupport.accept(List.of(MediaType.APPLICATION_JSON, MediaType.WILDCARD), req, resp);
                 if (accept.isEmpty()) {

--- a/servlet-api/src/main/java/openepcis/epc/eventhash/generator/servlet/EventHashGeneratorServlets.java
+++ b/servlet-api/src/main/java/openepcis/epc/eventhash/generator/servlet/EventHashGeneratorServlets.java
@@ -15,6 +15,7 @@
  */
 package openepcis.epc.eventhash.generator.servlet;
 
+import io.openepcis.constants.CBVVersion;
 import io.openepcis.epc.eventhash.DocumentWrapperSupport;
 import io.openepcis.epc.eventhash.EventHashGenerator;
 import io.openepcis.model.rest.servlet.ServletSupport;
@@ -70,6 +71,11 @@ public class EventHashGeneratorServlets {
                 // Add the Hash Algorithm type to the List.
                 final String hashAlgorithm = req.getParameter("hashAlgorithm");
                 hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
+
+                // Add provided CBV version else default to CBV 2.0.0
+                final String cbvVersion = Optional.ofNullable(req.getParameter("cbvVersion")).orElse("2.0.0");
+                final CBVVersion targetCbvVersion = "2.1.0".equals(cbvVersion) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+
                 Optional<String> accept = servletSupport.accept(List.of(MediaType.APPLICATION_JSON, MediaType.WILDCARD), req, resp);
                 if (accept.isEmpty()) {
                     return;
@@ -80,8 +86,8 @@ public class EventHashGeneratorServlets {
                 }
                 resp.setContentType(MediaType.APPLICATION_JSON);
                 servletSupport.writeJson(resp, contentType.get().contains("application/xml")
-                        ? eventHashGenerator.fromXml(req.getInputStream(), hashParameters.toArray(String[]::new))
-                        : eventHashGenerator.fromJson(
+                        ? eventHashGenerator.mapCbvVersion(targetCbvVersion).fromXml(req.getInputStream(), hashParameters.toArray(String[]::new))
+                        : eventHashGenerator.mapCbvVersion(targetCbvVersion).fromJson(
                         req.getInputStream(), hashParameters.toArray(String[]::new)));
             } catch (Exception e) {
                 final WebApplicationException webApplicationException =
@@ -129,6 +135,11 @@ public class EventHashGeneratorServlets {
                 // Add the Hash Algorithm type to the List.
                 final String hashAlgorithm = req.getParameter("hashAlgorithm");
                 hashParameters.add(hashAlgorithm != null && !hashAlgorithm.isEmpty() ? hashAlgorithm : SHA_256);
+
+                // Add provided CBV version else default to CBV 2.0.0
+                final String cbvVersion = Optional.ofNullable(req.getParameter("cbvVersion")).orElse("2.0.0");
+                final CBVVersion targetCbvVersion = "2.1.0".equals(cbvVersion) ? CBVVersion.VERSION_2_1_0 : CBVVersion.VERSION_2_0_0;
+
                 Optional<String> accept = servletSupport.accept(List.of(MediaType.APPLICATION_JSON, MediaType.WILDCARD), req, resp);
                 if (accept.isEmpty()) {
                     return;
@@ -139,8 +150,8 @@ public class EventHashGeneratorServlets {
                 }
                 resp.setContentType(MediaType.APPLICATION_JSON);
                 servletSupport.writeJson(resp, contentType.get().contains("application/xml")
-                        ? eventHashGenerator.fromXml(req.getInputStream(), hashParameters.toArray(String[]::new))
-                        : eventHashGenerator.fromJson(
+                        ? eventHashGenerator.mapCbvVersion(targetCbvVersion).fromXml(req.getInputStream(), hashParameters.toArray(String[]::new))
+                        : eventHashGenerator.mapCbvVersion(targetCbvVersion).fromJson(
                         documentWrapperSupport.generateJsonDocumentWrapper(req.getInputStream()), hashParameters.toArray(String[]::new)));
             } catch (Exception e) {
                 final WebApplicationException webApplicationException =


### PR DESCRIPTION
@sboeckelmann 

Based on your feedback following modifications have been made:
* Adding default and Parameterized constructor which can be used to set the CBV Version.
* Adding the support for CBV version in REST API and OpenAPI.
* Adding the support for CBV version in Servlets.
* Modifying the readme documentation.
* Testing the Hash-Id generation in cURL without any parameters.

Please review the changes and let me know if there is something that needs modification.