### PR TITLE
Convert the certificationInfo field from String to Array

### DIFF
--- a/core/src/main/java/io/openepcis/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/eventhash/ContextNode.java
@@ -190,7 +190,7 @@ public class ContextNode {
 
       // For ILMD fields make call to userExtensions formatter and for all other fields make call to
       // normal field formatter.
-      if (Boolean.TRUE.equals(isIlmdPath(this)) || Boolean.TRUE.equals(isIlmdPath(this))) {
+      if (Boolean.TRUE.equals(isIlmdPath(this))) {
         preHashBuilder.append(userExtensionsFormatter(name, value, namespaces));
       } else {
         // Add the values for direct name and value based on the field
@@ -274,7 +274,7 @@ public class ContextNode {
       path.push(fieldParent.getName());
       fieldParent = fieldParent.getParent();
     }
-    return path.contains(EPCIS.ILMD) || path.contains(EPCIS.CERTIFICATION_INFO);
+    return path.contains(EPCIS.ILMD);
   }
 
   // private method to find the parent of the element which can be later used to convert the Bare

--- a/core/src/main/java/io/openepcis/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/eventhash/ContextNode.java
@@ -123,6 +123,11 @@ public class ContextNode {
     while (fields.hasNext()) {
       var n = fields.next();
 
+      //Ignore reading the fields which are not required for Event Pre-Hash
+      if(ConstantEventHashInfo.getContext().getFieldsToExcludeInPrehash().contains(n.getKey())){
+        continue;
+      }
+
       // For event fields with direct string value add to childrens directs by calling Constructor
       // 1. Eg: type, bizStep, disposition, etc.
       if (n.getValue().isValueNode() && !n.getValue().isArray()) {
@@ -185,7 +190,7 @@ public class ContextNode {
 
       // For ILMD fields make call to userExtensions formatter and for all other fields make call to
       // normal field formatter.
-      if (Boolean.TRUE.equals(isIlmdOrCertificationPath(this)) || Boolean.TRUE.equals(isIlmdOrCertificationPath(this))) {
+      if (Boolean.TRUE.equals(isIlmdPath(this)) || Boolean.TRUE.equals(isIlmdPath(this))) {
         preHashBuilder.append(userExtensionsFormatter(name, value, namespaces));
       } else {
         // Add the values for direct name and value based on the field
@@ -226,7 +231,7 @@ public class ContextNode {
     // normal field formatter.
     String fieldName = "";
 
-    if (Boolean.TRUE.equals(isIlmdOrCertificationPath(node))) {
+    if (Boolean.TRUE.equals(isIlmdPath(node))) {
       if(!isArrayNode(node)){
         fieldName = userExtensionsFormatter(node.getName(), node.getValue(), namespaces);
       }
@@ -258,7 +263,7 @@ public class ContextNode {
 
   // Private function to store the path of the elements including the parents. Added to find the
   // ilmd elements and accordingly add the formatted ILMD elements
-  protected Boolean isIlmdOrCertificationPath(final ContextNode node) {
+  protected Boolean isIlmdPath(final ContextNode node) {
     // Special handling for the ILMD fields as it contains User Extensions like elements but should
     // appear before User-Extensions as well known fields of EPCIS standard.
     final Deque<String> path = new ArrayDeque<>();

--- a/core/src/main/java/io/openepcis/eventhash/HashNodeComparator.java
+++ b/core/src/main/java/io/openepcis/eventhash/HashNodeComparator.java
@@ -58,7 +58,7 @@ public class HashNodeComparator implements Comparator<ContextNode> {
       if (result == 0 && o1Index == -1 && o2Index == -1) {
         // Check if the element is of user extension
         if ((!TemplateNodeMap.isEpcisField(o1) && !TemplateNodeMap.isEpcisField(o2))
-            || (contextNode.isIlmdOrCertificationPath(o1) && contextNode.isIlmdOrCertificationPath(o2))) {
+            || (contextNode.isIlmdPath(o1) && contextNode.isIlmdPath(o2))) {
           // For user extensions consider the namespace and then sort
           return sortUserExtensions(o1, o2);
         } else if (o1.getChildren() != null && o2.getChildren() != null) {

--- a/core/src/main/java/io/openepcis/eventhash/constant/ConstantEventHashInfo.java
+++ b/core/src/main/java/io/openepcis/eventhash/constant/ConstantEventHashInfo.java
@@ -74,6 +74,7 @@ public class ConstantEventHashInfo {
               EPCIS.CORRECTIVE_EVENT_ID,
               EPCIS.RECORD_TIME,
               EPCIS.EVENT_ID,
+              EPCIS.CERTIFICATION_INFO,
               EPCIS.CONTEXT,
               "rdfs:comment",
               "#text",

--- a/core/src/test/java/io/openepcis/eventhash/EventHashGeneratorPublisherTest.java
+++ b/core/src/test/java/io/openepcis/eventhash/EventHashGeneratorPublisherTest.java
@@ -167,16 +167,12 @@ public class EventHashGeneratorPublisherTest {
             .getResourceAsStream(
                 "2.0/EPCIS/JSON/Capture/Documents/AggregationEvent_all_possible_fields.json");
 
+    final List<String> xmlHashIds =
+            eventHashGenerator.fromXml(xmlStream, "sha-256").subscribe().asStream().toList();
+    final List<String> jsonHashIds =
+            eventHashGenerator.fromJson(jsonStream, "sha-256").subscribe().asStream().toList();
 
-    final Multi<Map<String, String>> xmlEventHash = eventHashGenerator.fromXml(xmlStream, "prehash", "sha-256", CBVVersion.VERSION_2_0_0.getVersion());
-    xmlEventHash.subscribe().with(jsonHash -> System.out.println(jsonHash.get("sha-256") + "\n" + jsonHash.get("prehash") + "\n\n"), failure -> System.out.println("JSON HashId Generation Failed with " + failure));
-
-    System.out.println("*****************************???????????????????????????????????");
-    System.out.println("???????????????????????????????********************************");
-
-    final Multi<Map<String, String>> jsonEventHash = eventHashGenerator.fromJson(jsonStream, "prehash", "sha-256", CBVVersion.VERSION_2_0_0.getVersion());
-    jsonEventHash.subscribe().with(jsonHash -> System.out.println(jsonHash.get("sha-256") + "\n" + jsonHash.get("prehash") + "\n\n"), failure -> System.out.println("JSON HashId Generation Failed with " + failure));
-
+    assertEquals(xmlHashIds, jsonHashIds);
   }
 
   // Test to ensure that order of pre-hash always remains the same even when EPCIS document values


### PR DESCRIPTION
@sboeckelmann
As per the discussion, I have converted the certificationInfo field in our openepcis-models to Array. Accordingly, the other classes, tests, examples and hash generator were modified to fix the associated change issues. Kindly request you to review the changes and approve the PR.