### PR TITLE
GEN-315: Migrate to use the new openepcis-digital-link-converter-core instead of old openepcis-epc-digitallink-translator

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -67,7 +67,7 @@
         <!-- EPC/Class identifiers format converter-->
         <dependency>
             <groupId>io.openepcis</groupId>
-            <artifactId>openepcis-epc-digitallink-translator</artifactId>
+            <artifactId>openepcis-digital-link-converter-core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 

--- a/core/src/main/java/io/openepcis/eventhash/ContextNode.java
+++ b/core/src/main/java/io/openepcis/eventhash/ContextNode.java
@@ -21,11 +21,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.openepcis.constants.CBVVersion;
 import io.openepcis.constants.EPCIS;
-import io.openepcis.epc.translator.util.ConverterUtil;
 import io.openepcis.eventhash.constant.ConstantEventHashInfo;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import io.openepcis.identifiers.converter.util.ConverterUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;


### PR DESCRIPTION
@sboeckelmann 

As we have recently developed a new application for the `openepcis-digital-link-toolkit-build`, This PR contains the migration from the old `openepcis-epc-digitallink-translator` to the latest `openepcis-digital-link-converter-core`. 

Could you please review the PR and approve the changes?